### PR TITLE
Changed xrange to range

### DIFF
--- a/tests/test_feature_significance.py
+++ b/tests/test_feature_significance.py
@@ -55,7 +55,7 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 6):
+        for i in range(1, 6):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             if i == 1:
@@ -63,7 +63,7 @@ class FeatureSignificanceTestCase(TestCase):
             else:
                 self.assertEqual(row.type, "real")
 
-        for i in xrange(1, 10):
+        for i in range(1, 10):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             if i not in [3, 6, 9]:
@@ -123,12 +123,12 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 6):
+        for i in range(1, 6):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             self.assertEqual(row.type, "binary")
 
-        for i in xrange(1, 20):
+        for i in range(1, 20):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             self.assertEqual(row.type, "binary")
@@ -164,12 +164,12 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 5):
+        for i in range(1, 5):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             self.assertEqual(row.type, "real")
 
-        for i in xrange(1, 30):
+        for i in range(1, 30):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             self.assertEqual(row.type, "real")
@@ -210,7 +210,7 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 5):
+        for i in range(1, 5):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             if i == 1:
@@ -218,7 +218,7 @@ class FeatureSignificanceTestCase(TestCase):
             else:
                 self.assertEqual(row.type, "real")
 
-        for i in xrange(1, 10):
+        for i in range(1, 10):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             if i in [3, 6, 9]:


### PR DESCRIPTION
For https://github.com/blue-yonder/tsfresh/issues/8

This fixes the use of xrange function in tests/test_feature_significance.py

xrange has been removed in Python 3 and range in Python 3 is now the same as
xrange in Python 2.7.x (with a caveat that there is evidence that certain
Python 3 range usages are NOT a fast as Python 2.7.x xrange).

Searching the code xrange is only used in tests/test_feature_significance.py,
however that said in the master version there are only 2 calls to xrange and in
the i8_add_python3_support branch version there were 8, so @MaxBenChrist I am
not certain if there was a specific intention there.

All tests pass on Python 3.5.2, without handling the builtins in Python 2.7.x it
is not possible to say that if these tests pass on 2.7.x, it is a small change
and range works as xrange only slower, seeing as very large timeseries data
could be handled, it seems pertainent just to flag it up.

```
(tsfresh-py352) gary@mc11:/opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh$ ../../bin/python3.5 -m pytest tests/test_feature_significance.py
================================================================= test session starts =================================================================
platform linux -- Python 3.5.2, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- /opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh/../../bin/python3.5
cachedir: .cache
rootdir: /opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh, inifile: setup.cfg
plugins: xdist-1.15.0, cov-2.4.0
[gw0] linux Python 3.5.2 cwd: /opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh
[gw1] linux Python 3.5.2 cwd: /opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh
[gw2] linux Python 3.5.2 cwd: /opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh
[gw3] linux Python 3.5.2 cwd: /opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh
[gw0] Python 3.5.2 (default, Jul 11 2016, 13:20:59)  -- [GCC 4.8.4]
[gw2] Python 3.5.2 (default, Jul 11 2016, 13:20:59)  -- [GCC 4.8.4]
[gw1] Python 3.5.2 (default, Jul 11 2016, 13:20:59)  -- [GCC 4.8.4]
[gw3] Python 3.5.2 (default, Jul 11 2016, 13:20:59)  -- [GCC 4.8.4]
gw0 [14] / gw1 [14] / gw2 [14] / gw3 [14]
scheduling tests via LoadScheduling

tests/test_feature_significance.py::FeatureSignificanceTestCase::test_all_features_good
tests/test_feature_significance.py::FeatureSignificanceTestCase::test_binary_target_mixed_case
tests/test_feature_significance.py::FeatureSignificanceTestCase::test_binary_target_binary_features
tests/test_feature_significance.py::FeatureSignificanceTestCase::test_all_features_bad
[gw0] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCase::test_all_features_good
tests/test_feature_significance.py::FeatureSignificanceTestCase::test_real_target_binary_features
[gw2] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCase::test_all_features_bad
tests/test_feature_significance.py::FeatureSignificanceTestCase::test_binomial_target_realvalued_features
[gw0] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCase::test_real_target_binary_features
tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_all_features_good
[gw0] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_all_features_good
tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_binary_target_mixed_case
[gw2] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCase::test_binomial_target_realvalued_features
tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_binary_target_binary_features
[gw1] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCase::test_binary_target_mixed_case
tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_all_features_bad
[gw1] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_all_features_bad
[gw0] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_binary_target_mixed_case
[gw3] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCase::test_binary_target_binary_features
[gw2] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_binary_target_binary_features
tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_real_target_binary_features
tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_binomial_target_realvalued_features
tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_real_target_mixed_case
tests/test_feature_significance.py::FeatureSignificanceTestCase::test_real_target_mixed_case
[gw2] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_real_target_binary_features
[gw1] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_real_target_mixed_case
[gw3] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCase::test_real_target_mixed_case
[gw0] PASSED tests/test_feature_significance.py::FeatureSignificanceTestCaseWithOtherHypothesis::test_binomial_target_realvalued_features Coverage.py warning: No data was collected.


----------- coverage: platform linux, python 3.5.2-final-0 -----------
Name                                                 Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------------------------------
tsfresh/convenience/relevant_extraction.py              17     11      6      0    26%   43-60
tsfresh/examples/__init__.py                             2      2      0      0     0%   6-7
tsfresh/examples/robot_execution_failures.py            46     46     16      0     0%   5-121
tsfresh/feature_extraction/extraction.py                41     32     26      0    13%   67-101, 165-190
tsfresh/feature_extraction/feature_calculators.py      258    149     72      1    33%   56-60, 74-77, 105, 129, 149, 163, 177, 191, 204, 220, 242-250, 268-273, 291-292, 311, 329, 348-349, 362, 375, 389, 403, 417, 432-433, 448-449, 467, 482, 497, 512, 527, 541-542, 556-557, 571-572, 586-587, 608-618, 647-651, 670-675, 693, 721-746, 768-782, 808-833, 853-869, 906-913, 935-937, 953-954, 970-971, 984, 997, 1013-1016, 1034, 87->89
tsfresh/feature_extraction/settings.py                 116     96     87      0    10%   67-72, 81-107, 121-127, 148-198, 214-230, 244-278, 291-312
tsfresh/feature_selection/__init__.py                    2      0      0      0   100%
tsfresh/feature_selection/feature_selector.py           66      6     28      2    89%   88, 151-158, 87->88, 149->151
tsfresh/feature_selection/selection.py                  21     13     10      0    26%   85-102
tsfresh/feature_selection/settings.py                   11      0      0      0   100%
tsfresh/feature_selection/significance_tests.py         62     12     16      5    71%   121-126, 206, 208, 225-228, 245-248, 116->121, 205->206, 207->208, 224->225, 244->245
tsfresh/transformers/feature_augmenter.py               23     23      2      0     0%   5-140
tsfresh/transformers/feature_selector.py                21     21      8      0     0%   5-105
tsfresh/transformers/relevant_feature_augmenter.py      46     46     14      0     0%   5-238
tsfresh/utilities/dataframe_functions.py               103     91     86      0     6%   30-35, 57-58, 71-72, 100-134, 145-160, 178-186, 228-290
------------------------------------------------------------------------------------------------
TOTAL                                                  835    548    371      8    26%


============================================================== 14 passed in 5.27 seconds ==============================================================
```

