### PR TITLE
csort range py3 compatible

### DIFF
--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -9,6 +9,7 @@ from random import shuffle
 from unittest import TestCase
 from tsfresh.feature_extraction.feature_calculators import *
 from tsfresh.feature_extraction.feature_calculators import _get_length_sequences_where
+from sys import version_info
 
 
 class FeatureCalculationTestCase(TestCase):
@@ -279,7 +280,10 @@ class FeatureCalculationTestCase(TestCase):
         expected_index = ["TEST__index_mass_quantile__q_0.5"]
         res = index_mass_quantile(x, c, param)
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.5"], 0.5, places=1)
 
         x = [0] * 1000 + [1]
@@ -288,7 +292,10 @@ class FeatureCalculationTestCase(TestCase):
         expected_index = ["TEST__index_mass_quantile__q_0.5", "TEST__index_mass_quantile__q_0.99"]
         res = index_mass_quantile(x, c, param)
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.5"], 1, places=1)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.99"], 1, places=1)
 
@@ -299,7 +306,11 @@ class FeatureCalculationTestCase(TestCase):
                           "TEST__index_mass_quantile__q_0.9"]
         res = index_mass_quantile(x, c, param)
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.3"], 0.25, places=1)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.6"], 0.375, places=1)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.9"], 0.75, places=1)
@@ -331,7 +342,10 @@ class FeatureCalculationTestCase(TestCase):
         expected_index = ["TEST__ar_coefficient__k_1__coeff_0", "TEST__ar_coefficient__k_1__coeff_1"]
 
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_1__coeff_0"], 1, places=2)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_1__coeff_1"], 2.5, places=2)
 
@@ -350,10 +364,12 @@ class FeatureCalculationTestCase(TestCase):
                           "TEST__ar_coefficient__k_2__coeff_0", "TEST__ar_coefficient__k_2__coeff_1",
                           "TEST__ar_coefficient__k_2__coeff_2", "TEST__ar_coefficient__k_2__coeff_3"]
 
-
         print(res.sort_index())
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_2__coeff_0"], 1, places=2)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_2__coeff_1"], 3.5, places=2)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_2__coeff_2"], -2, places=2)

--- a/tests/feature_extraction/test_settings.py
+++ b/tests/feature_extraction/test_settings.py
@@ -9,6 +9,8 @@ from unittest import TestCase
 import numpy as np
 
 from tsfresh.feature_extraction.settings import FeatureExtractionSettings
+from sys import version_info
+
 
 class TestSettingsObject(TestCase):
 
@@ -36,9 +38,14 @@ class TestSettingsObject(TestCase):
 
         cset = fset.from_columns(feature_names)
 
-        self.assertItemsEqual(list(cset.kind_to_calculation_settings_mapping[tsn].keys()),
-                              ["sum_values", "median", "length", "quantile", "number_peaks", "ar_coefficient",
-                               "value_count"])
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(cset.kind_to_calculation_settings_mapping[tsn].keys()),
+                                  ["sum_values", "median", "length", "quantile", "number_peaks", "ar_coefficient",
+                                  "value_count"])
+        else:
+            self.assertCountEqual(list(cset.kind_to_calculation_settings_mapping[tsn].keys()),
+                                  ["sum_values", "median", "length", "quantile", "number_peaks", "ar_coefficient",
+                                  "value_count"])
 
         self.assertEqual(cset.kind_to_calculation_settings_mapping[tsn]["sum_values"], None)
         self.assertEqual(cset.kind_to_calculation_settings_mapping[tsn]["ar_coefficient"],

--- a/tests/feature_extraction/test_ts_features.py
+++ b/tests/feature_extraction/test_ts_features.py
@@ -8,6 +8,7 @@ import pandas as pd
 from tests.fixtures import DataTestCase
 from tsfresh.feature_extraction.extraction import extract_features
 from tsfresh.feature_extraction.settings import FeatureExtractionSettings
+from sys import version_info
 
 
 class FeatureExtractorTestCase(DataTestCase):
@@ -48,7 +49,10 @@ class FeatureExtractorTestCase(DataTestCase):
         extracted_features_from_random = extract_features(df_random, self.settings,
                                                           "id", "sort", "kind", "val").sort_index()
 
-        self.assertItemsEqual(extracted_features.columns, extracted_features_from_random.columns)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(extracted_features.columns, extracted_features_from_random.columns)
+        else:
+            self.assertCountEqual(extracted_features.columns, extracted_features_from_random.columns)
 
         for col in extracted_features:
             self.assertIsNone(np.testing.assert_array_almost_equal(extracted_features[col],

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -41,7 +41,11 @@ class DataTestCase(TestCase):
         :return: target y which is the mean of each sample's timeseries
         """
         cid = np.repeat(range(50), 3)
-        csort = range(3) * 50
+        # The csort was changed for Python 3 support
+        # https://github.com/blue-yonder/tsfresh/issues/8
+        # range has changed type in py3 from list to class
+        # csort = range(3) * 50
+        csort = list(range(3)) * 50
         cval = [1, 2, 3] * 30 + [4, 5, 6] * 20
         df = pd.DataFrame({'id': cid, 'kind': 'a', 'sort': csort, 'val': cval})
         y = pd.Series([2] * 30 + [5] * 20)

--- a/tests/test_feature_significance.py
+++ b/tests/test_feature_significance.py
@@ -55,7 +55,7 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 6):
+        for i in range(1, 6):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             if i == 1:
@@ -63,7 +63,7 @@ class FeatureSignificanceTestCase(TestCase):
             else:
                 self.assertEqual(row.type, "real")
 
-        for i in xrange(1, 10):
+        for i in range(1, 10):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             if i not in [3, 6, 9]:
@@ -123,12 +123,12 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 6):
+        for i in range(1, 6):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             self.assertEqual(row.type, "binary")
 
-        for i in xrange(1, 20):
+        for i in range(1, 20):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             self.assertEqual(row.type, "binary")
@@ -164,12 +164,12 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 5):
+        for i in range(1, 5):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             self.assertEqual(row.type, "real")
 
-        for i in xrange(1, 30):
+        for i in range(1, 30):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             self.assertEqual(row.type, "real")
@@ -210,7 +210,7 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 5):
+        for i in range(1, 5):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             if i == 1:
@@ -218,7 +218,7 @@ class FeatureSignificanceTestCase(TestCase):
             else:
                 self.assertEqual(row.type, "real")
 
-        for i in xrange(1, 10):
+        for i in range(1, 10):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             if i in [3, 6, 9]:

--- a/tests/transformers/test_feature_augmenter.py
+++ b/tests/transformers/test_feature_augmenter.py
@@ -25,6 +25,29 @@ class FeatureAugmenterTestCase(DataTestCase):
 
         # Fit should do nothing
         returned_df = augmenter.fit()
+        # Changed for py3 as unittest.assertEqual has changed a little
+        # TODO in progress
+        # Tried patterns, back at the original for now so can commit the
+        # assertItemsEqual assertCountEqual fix
+        # self.assertEqual(returned_df, augmenter)
+#>       self.assertEqual(list(X_transformed.columns), ["feature_1", "a__length", "b__length"])
+#E       AssertionError: Lists differ: ['feature_1', 'b__length', 'a__length'] != ['feature_1', 'a__length', 'b__length']
+#E
+#E       First differing element 1:
+#E       'b__length'
+#E       'a__length'
+#E
+#E       - ['feature_1', 'b__length', 'a__length']
+#E       + ['feature_1', 'a__length', 'b__length']
+
+#        self.assertEqual(sorted(returned_df), sorted((augmenter))
+#>       self.assertEqual(sorted(returned_df), sorted(augmenter))
+#E       TypeError: 'FeatureAugmenter' object is not iterable
+
+#        self.assertEqual(sorted(returned_df), sorted(list(augmenter)))
+#>       self.assertEqual(sorted(returned_df), sorted(list(augmenter)))
+#E       TypeError: 'FeatureAugmenter' object is not iterable
+
         self.assertEqual(returned_df, augmenter)
 
         self.assertRaises(RuntimeError, augmenter.transform, None)


### PR DESCRIPTION
In tests/fixtures.py csort does not work on 3.5 as range has changed type from
list to class in py3 - fixed and tested ok on 2.7 and 3.5

Implications of the type change of range from list to class in py3 could have
some deeper ramifications - https://github.com/blue-yonder/tsfresh/search?p=2&q=range

### debug info

```
tests/test_relevant_feature_extraction.py:25:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.test_relevant_feature_extraction.RelevantFeatureExtractionTestCase testMethod=test_functional_equality>

    def create_test_data_sample_with_target(self):
        """
            Small test data set with target.
            :return: timeseries df
            :return: target y which is the mean of each sample's timeseries
            """
        cid = np.repeat(range(50), 3)
>       csort = range(3) * 50
E       TypeError: unsupported operand type(s) for *: 'range' and 'int'

tests/fixtures.py:44: TypeError
=============================================================================================================== 1 failed in 2.56 seconds ================================================================================================================
(tsfresh-py352) gary@mc11:/opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh$
```

```
(tsfresh-py352) gary@mc11:/opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh$ python
Python 3.5.2 (default, Jul 11 2016, 13:20:59)
[GCC 4.8.4] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> csort = range(3) * 50
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for *: 'range' and 'int'
>>>
TypeError: unsupported operand type(s) for *: 'range' and 'int'
>>> range(3)
range(0, 3)
>>>
```

Fine on 2.7.12 as different implementation

```
(tsfresh-py2712) gary@mc11:/opt/python_virtualenv/projects/tsfresh-py2712/apps/tsfresh_master$ python
Python 2.7.12 (default, Aug 20 2016, 09:15:25)
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> csort = range(3) * 50
>>> print(csort)
[0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2]
>>> range(3)
[0, 1, 2]
>>>
```

### solve

Pattern that provides the same results on 2.7 and 3.5

```
(tsfresh-py352) gary@mc11:/opt/python_virtualenv/projects/tsfresh-py352/apps/tsfresh$ python
Python 3.5.2 (default, Jul 11 2016, 13:20:59)
[GCC 4.8.4] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> list(range(3))
[0, 1, 2]
>>> list(range(3)) * 50
[0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2]
>>>
```

```
(tsfresh-py2712) gary@mc11:/opt/python_virtualenv/projects/tsfresh-py2712/apps/tsfresh$ python
Python 2.7.12 (default, Aug 20 2016, 09:15:25)
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> list(range(3))
[0, 1, 2]
>>> list(range(3)) * 50
[0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2]
>>>
```

Changed and tests/test_relevant_feature_extraction.py works and passes on both
2.7.12 and 3.5.2.
