### PR TITLE
Use assertItemsEqual py2 and assertCountEqual py3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy>=0.17.0
 statsmodels>=0.6.1
 patsy>=0.4.1
 scikit-learn>=0.17.1
+future

--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division
 from __future__ import print_function
+from builtins import range
 from random import shuffle
 from unittest import TestCase
 from tsfresh.feature_extraction.feature_calculators import *

--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -9,6 +9,7 @@ from random import shuffle
 from unittest import TestCase
 from tsfresh.feature_extraction.feature_calculators import *
 from tsfresh.feature_extraction.feature_calculators import _get_length_sequences_where
+from sys import version_info
 
 
 class FeatureCalculationTestCase(TestCase):
@@ -279,7 +280,10 @@ class FeatureCalculationTestCase(TestCase):
         expected_index = ["TEST__index_mass_quantile__q_0.5"]
         res = index_mass_quantile(x, c, param)
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.5"], 0.5, places=1)
 
         x = [0] * 1000 + [1]
@@ -288,7 +292,10 @@ class FeatureCalculationTestCase(TestCase):
         expected_index = ["TEST__index_mass_quantile__q_0.5", "TEST__index_mass_quantile__q_0.99"]
         res = index_mass_quantile(x, c, param)
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.5"], 1, places=1)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.99"], 1, places=1)
 
@@ -299,7 +306,11 @@ class FeatureCalculationTestCase(TestCase):
                           "TEST__index_mass_quantile__q_0.9"]
         res = index_mass_quantile(x, c, param)
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.3"], 0.25, places=1)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.6"], 0.375, places=1)
         self.assertAlmostEqual(res["TEST__index_mass_quantile__q_0.9"], 0.75, places=1)
@@ -331,7 +342,10 @@ class FeatureCalculationTestCase(TestCase):
         expected_index = ["TEST__ar_coefficient__k_1__coeff_0", "TEST__ar_coefficient__k_1__coeff_1"]
 
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_1__coeff_0"], 1, places=2)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_1__coeff_1"], 2.5, places=2)
 
@@ -350,10 +364,12 @@ class FeatureCalculationTestCase(TestCase):
                           "TEST__ar_coefficient__k_2__coeff_0", "TEST__ar_coefficient__k_2__coeff_1",
                           "TEST__ar_coefficient__k_2__coeff_2", "TEST__ar_coefficient__k_2__coeff_3"]
 
-
         print(res.sort_index())
         self.assertIsInstance(res, pd.Series)
-        self.assertItemsEqual(list(res.index), expected_index)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(res.index), expected_index)
+        else:
+            self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_2__coeff_0"], 1, places=2)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_2__coeff_1"], 3.5, places=2)
         self.assertAlmostEqual(res["TEST__ar_coefficient__k_2__coeff_2"], -2, places=2)

--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -3,6 +3,7 @@
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
 from __future__ import absolute_import, division
+from __future__ import print_function
 from random import shuffle
 from unittest import TestCase
 from tsfresh.feature_extraction.feature_calculators import *

--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -154,7 +154,7 @@ class FeatureCalculationTestCase(TestCase):
         self.assertEqualOnAllArrayTypes(mean_change, [1, 2, -1], -1)
 
     def test_mean_second_derivate_central(self):
-        self.assertEqualOnAllArrayTypes(mean_second_derivate_central, range(10), 0)
+        self.assertEqualOnAllArrayTypes(mean_second_derivate_central, list(range(10)), 0)
         self.assertEqualOnAllArrayTypes(mean_second_derivate_central, [1, 3, 5], 0)
         self.assertEqualOnAllArrayTypes(mean_second_derivate_central, [1, 3, 7, -3], -3)
 
@@ -381,8 +381,8 @@ class FeatureCalculationTestCase(TestCase):
                                                                                   1 / 11 * np.math.log(1 / 11)), 10)
         self.assertAlmostEqualOnAllArrayTypes(binned_entropy, [10] * 10 + [1], - (10 / 11 * np.math.log(10 / 11) +
                                                                                   1 / 11 * np.math.log(1 / 11)), 100)
-        self.assertAlmostEqualOnAllArrayTypes(binned_entropy, range(10), - np.math.log(1 / 10), 100)
-        self.assertAlmostEqualOnAllArrayTypes(binned_entropy, range(100), - np.math.log(1 / 2), 2)
+        self.assertAlmostEqualOnAllArrayTypes(binned_entropy, list(range(10)), - np.math.log(1 / 10), 100)
+        self.assertAlmostEqualOnAllArrayTypes(binned_entropy, list(range(100)), - np.math.log(1 / 2), 2)
 
     def test_autocorrelation(self):
         self.assertAlmostEqualOnAllArrayTypes(autocorrelation, [1, 2, 1, 2, 1, 2], -1, 1)
@@ -400,8 +400,8 @@ class FeatureCalculationTestCase(TestCase):
 
     def test_mean_abs_change_quantiles(self):
 
-        self.assertAlmostEqualOnAllArrayTypes(mean_abs_change_quantiles, range(10), 1, ql=0.1, qh=0.9)
-        self.assertAlmostEqualOnAllArrayTypes(mean_abs_change_quantiles, range(10), 0, ql=0.15, qh=0.18)
+        self.assertAlmostEqualOnAllArrayTypes(mean_abs_change_quantiles, list(range(10)), 1, ql=0.1, qh=0.9)
+        self.assertAlmostEqualOnAllArrayTypes(mean_abs_change_quantiles, list(range(10)), 0, ql=0.15, qh=0.18)
         self.assertAlmostEqualOnAllArrayTypes(mean_abs_change_quantiles, [0, 1, 0, 0, 0], 0.5, ql=0, qh=1)
         self.assertAlmostEqualOnAllArrayTypes(mean_abs_change_quantiles, [0, 1, 0, 0, 0], 0.5, ql=0.1, qh=1)
         self.assertAlmostEqualOnAllArrayTypes(mean_abs_change_quantiles, [0, 1, 0, 0, 0], 0, ql=0.1, qh=0.6)
@@ -411,7 +411,7 @@ class FeatureCalculationTestCase(TestCase):
 
     def test_value_count(self):
         self.assertEqualPandasSeriesWrapper(value_count, [1] * 10, 10, value=1)
-        self.assertEqualPandasSeriesWrapper(value_count, range(10), 1, value=0)
+        self.assertEqualPandasSeriesWrapper(value_count, list(range(10)), 1, value=0)
         self.assertEqualPandasSeriesWrapper(value_count, [1] * 10, 0, value=0)
         self.assertEqualPandasSeriesWrapper(value_count, [np.NaN, 0, 1] * 3, 3, value=0)
         self.assertEqualPandasSeriesWrapper(value_count, [np.NINF, 0, 1] * 3, 3, value=0)
@@ -425,7 +425,7 @@ class FeatureCalculationTestCase(TestCase):
         self.assertEqualPandasSeriesWrapper(range_count, [1] * 10, 0, min=1, max=1)
         self.assertEqualPandasSeriesWrapper(range_count, [1] * 10, 0, min=0.9, max=1)
         self.assertEqualPandasSeriesWrapper(range_count, [1] * 10, 10, min=1, max=1.1)
-        self.assertEqualPandasSeriesWrapper(range_count, range(10), 9, min=0, max=9)
-        self.assertEqualPandasSeriesWrapper(range_count, range(10), 10, min=0, max=10)
-        self.assertEqualPandasSeriesWrapper(range_count, range(0, -10, -1), 9, min=-10, max=0)
-        self.assertEqualPandasSeriesWrapper(range_count, [np.NaN, np.PINF, np.NINF] + range(10), 10, min=0, max=10)
+        self.assertEqualPandasSeriesWrapper(range_count, list(range(10)), 9, min=0, max=9)
+        self.assertEqualPandasSeriesWrapper(range_count, list(range(10)), 10, min=0, max=10)
+        self.assertEqualPandasSeriesWrapper(range_count, list(range(0, -10, -1)), 9, min=-10, max=0)
+        self.assertEqualPandasSeriesWrapper(range_count, [np.NaN, np.PINF, np.NINF] + list(range(10)), 10, min=0, max=10)

--- a/tests/feature_extraction/test_settings.py
+++ b/tests/feature_extraction/test_settings.py
@@ -9,6 +9,8 @@ from unittest import TestCase
 import numpy as np
 
 from tsfresh.feature_extraction.settings import FeatureExtractionSettings
+from sys import version_info
+
 
 class TestSettingsObject(TestCase):
 
@@ -36,9 +38,14 @@ class TestSettingsObject(TestCase):
 
         cset = fset.from_columns(feature_names)
 
-        self.assertItemsEqual(list(cset.kind_to_calculation_settings_mapping[tsn].keys()),
-                              ["sum_values", "median", "length", "quantile", "number_peaks", "ar_coefficient",
-                               "value_count"])
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(list(cset.kind_to_calculation_settings_mapping[tsn].keys()),
+                                  ["sum_values", "median", "length", "quantile", "number_peaks", "ar_coefficient",
+                                  "value_count"])
+        else:
+            self.assertCountEqual(list(cset.kind_to_calculation_settings_mapping[tsn].keys()),
+                                  ["sum_values", "median", "length", "quantile", "number_peaks", "ar_coefficient",
+                                  "value_count"])
 
         self.assertEqual(cset.kind_to_calculation_settings_mapping[tsn]["sum_values"], None)
         self.assertEqual(cset.kind_to_calculation_settings_mapping[tsn]["ar_coefficient"],

--- a/tests/feature_extraction/test_settings.py
+++ b/tests/feature_extraction/test_settings.py
@@ -36,7 +36,7 @@ class TestSettingsObject(TestCase):
 
         cset = fset.from_columns(feature_names)
 
-        self.assertItemsEqual(cset.kind_to_calculation_settings_mapping[tsn].keys(),
+        self.assertItemsEqual(list(cset.kind_to_calculation_settings_mapping[tsn].keys()),
                               ["sum_values", "median", "length", "quantile", "number_peaks", "ar_coefficient",
                                "value_count"])
 

--- a/tests/feature_extraction/test_ts_features.py
+++ b/tests/feature_extraction/test_ts_features.py
@@ -8,6 +8,7 @@ import pandas as pd
 from tests.fixtures import DataTestCase
 from tsfresh.feature_extraction.extraction import extract_features
 from tsfresh.feature_extraction.settings import FeatureExtractionSettings
+from sys import version_info
 
 
 class FeatureExtractorTestCase(DataTestCase):
@@ -48,7 +49,10 @@ class FeatureExtractorTestCase(DataTestCase):
         extracted_features_from_random = extract_features(df_random, self.settings,
                                                           "id", "sort", "kind", "val").sort_index()
 
-        self.assertItemsEqual(extracted_features.columns, extracted_features_from_random.columns)
+        if int(version_info[0]) == 2:
+            self.assertItemsEqual(extracted_features.columns, extracted_features_from_random.columns)
+        else:
+            self.assertCountEqual(extracted_features.columns, extracted_features_from_random.columns)
 
         for col in extracted_features:
             self.assertIsNone(np.testing.assert_array_almost_equal(extracted_features[col],

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -41,7 +41,11 @@ class DataTestCase(TestCase):
         :return: target y which is the mean of each sample's timeseries
         """
         cid = np.repeat(range(50), 3)
-        csort = range(3) * 50
+        # The csort was changed for Python 3 support
+        # https://github.com/blue-yonder/tsfresh/issues/8
+        # range has changed type in py3 from list to class
+        # csort = range(3) * 50
+        csort = list(range(3)) * 50
         cval = [1, 2, 3] * 30 + [4, 5, 6] * 20
         df = pd.DataFrame({'id': cid, 'kind': 'a', 'sort': csort, 'val': cval})
         y = pd.Series([2] * 30 + [5] * 20)

--- a/tests/test_feature_significance.py
+++ b/tests/test_feature_significance.py
@@ -55,7 +55,7 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 6):
+        for i in range(1, 6):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             if i == 1:
@@ -63,7 +63,7 @@ class FeatureSignificanceTestCase(TestCase):
             else:
                 self.assertEqual(row.type, "real")
 
-        for i in xrange(1, 10):
+        for i in range(1, 10):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             if i not in [3, 6, 9]:
@@ -123,12 +123,12 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 6):
+        for i in range(1, 6):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             self.assertEqual(row.type, "binary")
 
-        for i in xrange(1, 20):
+        for i in range(1, 20):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             self.assertEqual(row.type, "binary")
@@ -164,12 +164,12 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 5):
+        for i in range(1, 5):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             self.assertEqual(row.type, "real")
 
-        for i in xrange(1, 30):
+        for i in range(1, 30):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             self.assertEqual(row.type, "real")
@@ -210,7 +210,7 @@ class FeatureSignificanceTestCase(TestCase):
         self.assertGreater(len(feat_rej), 0)
 
         # Test type outputs
-        for i in xrange(1, 5):
+        for i in range(1, 5):
             row = df_bh.loc["rel{}".format(i)]
             self.assertEqual(row.Feature, "rel{}".format(i))
             if i == 1:
@@ -218,7 +218,7 @@ class FeatureSignificanceTestCase(TestCase):
             else:
                 self.assertEqual(row.type, "real")
 
-        for i in xrange(1, 10):
+        for i in range(1, 10):
             row = df_bh.loc["irr{}".format(i)]
             self.assertEqual(row.Feature, "irr{}".format(i))
             if i in [3, 6, 9]:

--- a/tests/transformers/test_feature_augmenter.py
+++ b/tests/transformers/test_feature_augmenter.py
@@ -25,6 +25,29 @@ class FeatureAugmenterTestCase(DataTestCase):
 
         # Fit should do nothing
         returned_df = augmenter.fit()
+        # Changed for py3 as unittest.assertEqual has changed a little
+        # TODO in progress
+        # Tried patterns, back at the original for now so can commit the
+        # assertItemsEqual assertCountEqual fix
+        # self.assertEqual(returned_df, augmenter)
+#>       self.assertEqual(list(X_transformed.columns), ["feature_1", "a__length", "b__length"])
+#E       AssertionError: Lists differ: ['feature_1', 'b__length', 'a__length'] != ['feature_1', 'a__length', 'b__length']
+#E
+#E       First differing element 1:
+#E       'b__length'
+#E       'a__length'
+#E
+#E       - ['feature_1', 'b__length', 'a__length']
+#E       + ['feature_1', 'a__length', 'b__length']
+
+#        self.assertEqual(sorted(returned_df), sorted((augmenter))
+#>       self.assertEqual(sorted(returned_df), sorted(augmenter))
+#E       TypeError: 'FeatureAugmenter' object is not iterable
+
+#        self.assertEqual(sorted(returned_df), sorted(list(augmenter)))
+#>       self.assertEqual(sorted(returned_df), sorted(list(augmenter)))
+#E       TypeError: 'FeatureAugmenter' object is not iterable
+
         self.assertEqual(returned_df, augmenter)
 
         self.assertRaises(RuntimeError, augmenter.transform, None)

--- a/tests/transformers/test_feature_augmenter.py
+++ b/tests/transformers/test_feature_augmenter.py
@@ -2,6 +2,7 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
+from __future__ import print_function
 import pandas as pd
 from tests.fixtures import DataTestCase
 from tsfresh.feature_extraction.settings import FeatureExtractionSettings
@@ -48,7 +49,7 @@ class FeatureAugmenterTestCase(DataTestCase):
 
         # Features are not allowed to be NaN
         for index, row in X_transformed.iterrows():
-            print(index, row)
+            print((index, row))
             self.assertFalse(np.isnan(row["a__length"]))
             self.assertFalse(np.isnan(row["b__length"]))
 
@@ -72,6 +73,6 @@ class FeatureAugmenterTestCase(DataTestCase):
 
         # Features are not allowed to be NaN
         for index, row in X_transformed.iterrows():
-            print(index, row)
+            print((index, row))
             self.assertFalse(np.isnan(row["a__length"]))
             self.assertFalse(np.isnan(row["b__length"]))

--- a/tests/transformers/test_feature_selector.py
+++ b/tests/transformers/test_feature_selector.py
@@ -2,6 +2,7 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
+from builtins import range
 from unittest import TestCase
 import pandas as pd
 

--- a/tests/transformers/test_feature_selector.py
+++ b/tests/transformers/test_feature_selector.py
@@ -26,7 +26,7 @@ class FeatureSelectorTestCase(TestCase):
         selector = FeatureSelector()
 
         y = pd.Series(np.random.binomial(1, 0.5, 1000))
-        X = pd.DataFrame(index=range(1000))
+        X = pd.DataFrame(index=list(range(1000)))
 
         z = y - np.random.binomial(1, 0.1, 1000) + np.random.binomial(1, 0.1, 1000)
         z[z == -1] = 0
@@ -65,7 +65,7 @@ class FeatureSelectorTestCase(TestCase):
         selector = FeatureSelector()
 
         y = pd.Series(np.random.binomial(1, 0.5, 1000))
-        X = pd.DataFrame(index=range(1000))
+        X = pd.DataFrame(index=list(range(1000)))
 
         X["irr1"] = np.random.normal(0, 1, 1000)
         X["irr2"] = np.random.normal(2, 1, 1000)
@@ -81,7 +81,7 @@ class FeatureSelectorTestCase(TestCase):
         selector = FeatureSelector()
 
         y = pd.Series(np.random.binomial(1, 0.5, 1000))
-        X = pd.DataFrame(index=range(1000))
+        X = pd.DataFrame(index=list(range(1000)))
 
         X["irr1"] = np.random.normal(0, 1, 1000)
         X["rel1"] = y

--- a/tests/utilities/test_dataframe_functions.py
+++ b/tests/utilities/test_dataframe_functions.py
@@ -28,7 +28,7 @@ class NormalizeTestCase(TestCase):
             dataframe_functions.normalize_input_to_internal_representation(test_dict, "id", None, None, "value")
         self.assertEqual(column_value, "value")
         self.assertEqual(column_id, "id")
-        self.assertEqual(test_dict.keys(), result_dict.keys())
+        self.assertEqual(list(test_dict.keys()), list(result_dict.keys()))
         self.assertEqual(result_dict["a"].iloc[0].to_dict(), {"value": 1, "id": "id_1"})
 
         # The algo should choose the correct value column

--- a/tsfresh/examples/__init__.py
+++ b/tsfresh/examples/__init__.py
@@ -3,4 +3,5 @@ Module with exemplary data sets to play around with.
 
 See for eample the :ref:`quick-start-label` section on how to use them.
 """
-from robot_execution_failures import load_robot_execution_failures, download_robot_execution_failures
+from __future__ import absolute_import
+from .robot_execution_failures import load_robot_execution_failures, download_robot_execution_failures

--- a/tsfresh/examples/robot_execution_failures.py
+++ b/tsfresh/examples/robot_execution_failures.py
@@ -111,7 +111,7 @@ def load_robot_execution_failures():
                     id_to_target[cur_id] = 1
             # Data row --> split and convert values, create complete df row
             elif line[0] == '\t':
-                values = map(int, line.split('\t')[1:])
+                values = list(map(int, line.split('\t')[1:]))
                 df_rows.append([cur_id, time] + values)
                 time += 1
 

--- a/tsfresh/examples/robot_execution_failures.py
+++ b/tsfresh/examples/robot_execution_failures.py
@@ -22,6 +22,7 @@ References
 
 from __future__ import absolute_import, division
 
+from builtins import map
 import os
 import pandas as pd
 import requests

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -79,12 +79,12 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
         profiler = profiling.start_profiling()
 
     # Extract the time series features for every type of time series and concatenate them together.
-    all_possible_unique_id_values = set(id_value for kind, df in kind_to_df_map.iteritems()
+    all_possible_unique_id_values = set(id_value for kind, df in kind_to_df_map.items()
                                         for id_value in df[column_id])
     df_with_ids = pd.DataFrame(index=all_possible_unique_id_values)
     extracted_features = [_extract_features_for_one_time_series(relevant_time_series, str(kind),
                                                                 column_id, column_value, feature_extraction_settings)
-                          for kind, relevant_time_series in kind_to_df_map.iteritems()]
+                          for kind, relevant_time_series in kind_to_df_map.items()]
 
     # Add time series features to result
     result = pd.concat([df_with_ids] + extracted_features, axis=1, join='outer', join_axes=[df_with_ids.index]).astype(np.float64)

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -6,6 +6,7 @@ This module contains the main function to interact with tsfresh: extract feature
 """
 
 from __future__ import absolute_import, division
+from builtins import str
 import pandas as pd
 import numpy as np
 from tsfresh.utilities import dataframe_functions, profiling

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -690,7 +690,7 @@ def number_cwt_peaks(x, n):
     :return: the value of this feature
     :return type: int
     """
-    return len(find_peaks_cwt(vector=x, widths=np.array(range(1, n + 1)), wavelet=ricker))
+    return len(find_peaks_cwt(vector=x, widths=np.array(list(range(1, n + 1))), wavelet=ricker))
 
 
 @set_property("fctype", "apply")

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -25,6 +25,7 @@ import pandas as pd
 from scipy.signal import welch, cwt, ricker, find_peaks_cwt
 from statsmodels.tsa.ar_model import AR
 from statsmodels.tsa.stattools import adfuller
+from functools import reduce
 
 
 # todo: make sure '_' works in parameter names in all cases, add a warning if not

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -15,6 +15,7 @@ can be used with pandas apply.
 """
 
 from __future__ import absolute_import, division
+from builtins import range
 import itertools
 import numpy as np
 from numpy.linalg import LinAlgError

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -8,7 +8,11 @@ For the naming of the features, see :ref:`feature-naming-label`.
 """
 
 from __future__ import absolute_import
+from builtins import zip
+from builtins import str
 from builtins import range
+from past.builtins import basestring
+from builtins import object
 import ast
 from functools import partial
 

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -23,7 +23,7 @@ from tsfresh.utilities.dataframe_functions import impute_dataframe_zero
 
 
 # todo: this classes' docstrings are not completely up-to-date
-class FeatureExtractionSettings:
+class FeatureExtractionSettings(object):
     """
     This class defines the behaviour of feature extraction, in particular which feature and parameter combinations are calculated.
     If you do not specify any user settings, all features will be extracted with default arguments defined in this class.

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -144,8 +144,8 @@ class FeatureExtractionSettings:
 
         for col in columns:
 
-            if not isinstance(col, str):
-                raise TypeError("Column name {} should be a string".format(col))
+            if not isinstance(col, basestring):
+                raise TypeError("Column name {} should be a string or unicode".format(col))
 
             # Split according to our separator into <col_name>, <feature_name>, <feature_params>
             parts = col.split('__')

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -79,7 +79,7 @@ class FeatureExtractionSettings(object):
         :return:
         """
         name_to_param = {}
-        for name, func in feature_calculators.__dict__.iteritems():
+        for name, func in feature_calculators.__dict__.items():
             if callable(func):
                 if hasattr(func, "fctype"):
                     name_to_param[name] = None
@@ -246,7 +246,7 @@ class FeatureExtractionSettings(object):
         if kind not in self.kind_to_calculation_settings_mapping:
             return aggregate_functions
 
-        for name, param in self.kind_to_calculation_settings_mapping[kind].iteritems():
+        for name, param in self.kind_to_calculation_settings_mapping[kind].items():
 
             func = getattr(feature_calculators, name)
 
@@ -266,7 +266,7 @@ class FeatureExtractionSettings(object):
 
                     # if there are several params, create a feature for each one
                     c = '{}__{}'.format(kind, name)
-                    for arg, p in config.iteritems():
+                    for arg, p in config.items():
                         c += "__" + arg + "_" + str(p)
                     aggregate_functions[c] = partial(func, **config)
 
@@ -293,7 +293,7 @@ class FeatureExtractionSettings(object):
         if column_prefix not in self.kind_to_calculation_settings_mapping:
             return apply_functions
 
-        for name, param in self.kind_to_calculation_settings_mapping[column_prefix].iteritems():
+        for name, param in self.kind_to_calculation_settings_mapping[column_prefix].items():
 
             func = getattr(feature_calculators, name)
 

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -8,6 +8,7 @@ For the naming of the features, see :ref:`feature-naming-label`.
 """
 
 from __future__ import absolute_import
+from builtins import range
 import ast
 from functools import partial
 

--- a/tsfresh/feature_selection/feature_selector.py
+++ b/tsfresh/feature_selection/feature_selector.py
@@ -12,6 +12,7 @@ which to cut off (solely based on the p-values).
 
 from __future__ import absolute_import, division, print_function
 
+from builtins import range
 import os
 import numpy as np
 import pandas as pd

--- a/tsfresh/feature_selection/feature_selector.py
+++ b/tsfresh/feature_selection/feature_selector.py
@@ -12,6 +12,7 @@ which to cut off (solely based on the p-values).
 
 from __future__ import absolute_import, division, print_function
 
+from builtins import zip
 from builtins import range
 import os
 import numpy as np

--- a/tsfresh/feature_selection/feature_selector.py
+++ b/tsfresh/feature_selection/feature_selector.py
@@ -193,7 +193,7 @@ def benjamini_hochberg_test(df_pvalues, settings):
     # Get auxiliary variables and vectors
     df_pvalues = df_pvalues.sort_values(by="p_value")
     m = len(df_pvalues)
-    K = range(1, m + 1)
+    K = list(range(1, m + 1))
 
     # Calculate the weight vector C
     if settings.hypotheses_independent:

--- a/tsfresh/feature_selection/settings.py
+++ b/tsfresh/feature_selection/settings.py
@@ -2,7 +2,8 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
-class FeatureSignificanceTestsSettings:
+from builtins import object
+class FeatureSignificanceTestsSettings(object):
     """
     The settings object for controlling the feature significance tests.
     Normally, you do not have to handle these settings on your own, as the chosen defaults are quite sensible.

--- a/tsfresh/feature_selection/significance_tests.py
+++ b/tsfresh/feature_selection/significance_tests.py
@@ -27,6 +27,7 @@ References
 
 
 from __future__ import absolute_import, division
+from builtins import str
 import numpy as np
 import pandas as pd
 from scipy import stats

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -179,7 +179,7 @@ def restrict_input_to_index(df_or_dict, column_id, index):
         df_or_dict_restricted = df_or_dict[df_or_dict[column_id].isin(index)]
     elif isinstance(df_or_dict, dict):
         df_or_dict_restricted = {kind: df[df[column_id].isin(index)]
-                                  for kind, df in df_or_dict.iteritems()}
+                                  for kind, df in df_or_dict.items()}
     else:
         raise TypeError("df_or_dict should be of type dict or pandas.DataFrame")
 
@@ -228,7 +228,7 @@ def normalize_input_to_internal_representation(df_or_dict, column_id, column_sor
     if isinstance(df_or_dict, dict):
         if column_kind:
             raise ValueError("You passed in a dictionary and gave a column name for the kind. Both is not possible.")
-        kind_to_df_map = {key: df.copy() for key, df in df_or_dict.iteritems()}
+        kind_to_df_map = {key: df.copy() for key, df in df_or_dict.items()}
     else:
         if column_kind:
             kind_to_df_map = {key: group.copy().drop(column_kind, axis=1) for key, group in df_or_dict.groupby(column_kind)}

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -236,7 +236,7 @@ def normalize_input_to_internal_representation(df_or_dict, column_id, column_sor
             if column_value:
                 kind_to_df_map = {"feature": df_or_dict.copy()}
             else:
-                id_and_sort_column = filter(None, [column_id, column_sort])
+                id_and_sort_column = [_f for _f in [column_id, column_sort] if _f]
                 kind_to_df_map = {key: df_or_dict[[key] + id_and_sort_column].copy().rename(columns={key: "_value"})
                                   for key in df_or_dict.columns if key not in id_and_sort_column}
 

--- a/tsfresh/utilities/profiling.py
+++ b/tsfresh/utilities/profiling.py
@@ -5,7 +5,9 @@
 Contains methods to start and stop the profiler that checks the runtime of the different feature calculators
 """
 
-import cProfile, pstats, StringIO
+from future import standard_library
+standard_library.install_aliases()
+import cProfile, pstats, io
 import logging
 
 
@@ -55,7 +57,7 @@ def end_profiling(profiler, sorting, filename):
     >>> end_profiling(profiler, "cumulative", "out.txt")
     """
     profiler.disable()
-    s = StringIO.StringIO()
+    s = io.StringIO()
     ps = pstats.Stats(profiler, stream=s).sort_stats(sorting)
     ps.print_stats()
 


### PR DESCRIPTION
Due to a change in unittest in as identified by @jneuff in https://github.com/blue-yonder/tsfresh/issues/8#issuecomment-257985520

Semantically assertItemsEqual py2 and assertCountEqual py3 appear to be the same and this fixes the related failing tests on Python 3.5

This also adds a basic method to determine python version for now, I am only committing so that
the new deeper unitest.assertEqual issue that now presents itself can be addressed.
