### PR TITLE
Add iloc to run_tsfresh.py

### DIFF
--- a/scripts/run_tsfresh.py
+++ b/scripts/run_tsfresh.py
@@ -36,8 +36,8 @@ def _preprocess(df):
 	master_df = pd.DataFrame(df_t[0])
 	master_df['id'] = 0
 
-	for i in range(1, 50):
-	    temp_df = pd.DataFrame(df_t[i])
+	for i in range(0, 49):
+	    temp_df = pd.DataFrame(df_t.iloc[i])
 	    temp_df['id'] = i
 	    master_df = pd.DataFrame(np.vstack([master_df, temp_df]))
 	return master_df


### PR DESCRIPTION
iloc is required to get it working on both 2.7 and 3.5.

If the sample of 50 is going to be used then it should really begin at 0 as then
the df is 0 indexed.

That said however I would suggest that the 50 sample be removed as it is not
really useful per se as it is.  It may as well take as much time as it needs to
take for real usage so that it can be used as required.

I shall add that as another pull request to add iloc and remove the sampling of the first 50 and you can take your pick, if you wish to use either.