### PR TITLE
Provide p-values of selected features

### DIFF
--- a/tests/transformers/test_feature_selector.py
+++ b/tests/transformers/test_feature_selector.py
@@ -113,4 +113,20 @@ class FeatureSelectorTestCase(TestCase):
         selector.fit(X, y)
 
         self.assertEqual(selector.feature_importance_.shape, (2,))
+
+    def test_feature_importance(self):
+        selector = FeatureSelector()
+        self.assertTrue(selector.p_values is None)
         
+        y = pd.Series(np.random.binomial(1, 0.5, 1000))
+        X = pd.DataFrame(index=list(range(1000)))
+
+        X["irr1"] = np.random.normal(0, 1, 1000)
+        X["rel1"] = y
+
+        selector.fit(X, y)
+
+        self.assertEqual(selector.p_values.shape, (2,))
+        np.testing.assert_almost_equal(selector.p_values,
+                                       1.0-selector.feature_importance_)
+

--- a/tests/transformers/test_feature_selector.py
+++ b/tests/transformers/test_feature_selector.py
@@ -61,6 +61,8 @@ class FeatureSelectorTestCase(TestCase):
 
         self.assertEqual(sorted(selector.relevant_features), sorted(list(selected_X.columns)))
 
+        self.assertEqual(len(selector.features), len(X.columns))
+
     def test_nothing_relevant(self):
         selector = FeatureSelector()
 
@@ -98,7 +100,6 @@ class FeatureSelectorTestCase(TestCase):
         self.assertTrue((selected_X_numpy == selected_X.values).all())
 
         self.assertTrue(selected_X_numpy.shape, (1, 1000))
-
         
     def test_feature_importance(self):
         selector = FeatureSelector()

--- a/tests/transformers/test_feature_selector.py
+++ b/tests/transformers/test_feature_selector.py
@@ -102,7 +102,7 @@ class FeatureSelectorTestCase(TestCase):
         
     def test_feature_importance(self):
         selector = FeatureSelector()
-        self.assertTrue(selector.feature_importance_ is None)
+        self.assertTrue(selector.feature_importances_ is None)
         
         y = pd.Series(np.random.binomial(1, 0.5, 1000))
         X = pd.DataFrame(index=list(range(1000)))
@@ -112,7 +112,7 @@ class FeatureSelectorTestCase(TestCase):
 
         selector.fit(X, y)
 
-        self.assertEqual(selector.feature_importance_.shape, (2,))
+        self.assertEqual(selector.feature_importances_.shape, (2,))
 
     def test_feature_importance(self):
         selector = FeatureSelector()
@@ -128,5 +128,5 @@ class FeatureSelectorTestCase(TestCase):
 
         self.assertEqual(selector.p_values.shape, (2,))
         np.testing.assert_almost_equal(selector.p_values,
-                                       1.0-selector.feature_importance_)
+                                       1.0-selector.feature_importances_)
 

--- a/tests/transformers/test_feature_selector.py
+++ b/tests/transformers/test_feature_selector.py
@@ -53,13 +53,13 @@ class FeatureSelectorTestCase(TestCase):
         returned_selector = selector.fit(X, y)
         self.assertIs(returned_selector, selector)
 
-        self.assertEqual(sorted(list(selector.relevant_features.index)), ["rel1", "rel2", "rel3", "rel4", "rel5"])
+        self.assertEqual(sorted(selector.relevant_features), ["rel1", "rel2", "rel3", "rel4", "rel5"])
 
         new_X = X.copy()
 
         selected_X = selector.transform(new_X)
 
-        self.assertEqual(sorted(list(selector.relevant_features.index)), sorted(list(selected_X.columns)))
+        self.assertEqual(sorted(selector.relevant_features), sorted(list(selected_X.columns)))
 
     def test_nothing_relevant(self):
         selector = FeatureSelector()

--- a/tests/transformers/test_feature_selector.py
+++ b/tests/transformers/test_feature_selector.py
@@ -99,5 +99,18 @@ class FeatureSelectorTestCase(TestCase):
 
         self.assertTrue(selected_X_numpy.shape, (1, 1000))
 
+        
+    def test_feature_importance(self):
+        selector = FeatureSelector()
+        self.assertTrue(selector.feature_importance_ is None)
+        
+        y = pd.Series(np.random.binomial(1, 0.5, 1000))
+        X = pd.DataFrame(index=list(range(1000)))
 
+        X["irr1"] = np.random.normal(0, 1, 1000)
+        X["rel1"] = y
 
+        selector.fit(X, y)
+
+        self.assertEqual(selector.feature_importance_.shape, (2,))
+        

--- a/tsfresh/transformers/feature_selector.py
+++ b/tsfresh/transformers/feature_selector.py
@@ -39,7 +39,7 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
     >>> []
 
     The same holds for the feature importance:
-    >>> selector.feature_importance_
+    >>> selector.feature_importances_
     >>> array([], dtype=float64)
 
     The estimator keeps track on those features, that were relevant in the training step. If you
@@ -91,7 +91,7 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
         :type chunksize: int
         """
         self.relevant_features = None
-        self.feature_importance_ = None
+        self.feature_importances_ = None
         self.p_values = None
 
         self.test_for_binary_target_binary_feature = test_for_binary_target_binary_feature
@@ -132,7 +132,7 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
                                 self.fdr_level, self.hypotheses_independent,
                                 self.test_for_binary_target_real_feature)
         self.relevant_features = df_bh.loc[df_bh.rejected].Feature.tolist()
-        self.feature_importance_ = 1.0 - df_bh.p_value.values
+        self.feature_importances_ = 1.0 - df_bh.p_value.values
         self.p_values = df_bh.p_value.values
 
         return self

--- a/tsfresh/transformers/feature_selector.py
+++ b/tsfresh/transformers/feature_selector.py
@@ -116,9 +116,10 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
         if not isinstance(y, pd.Series):
             y = pd.Series(y.copy())
 
-        df_bh = check_fs_sig_bh(X, y, self.n_processes, self.chunksize, self.fdr_level, self.hypotheses_independent,
+        df_bh = check_fs_sig_bh(X, y, self.n_processes, self.chunksize,
+                                self.fdr_level, self.hypotheses_independent,
                                 self.test_for_binary_target_real_feature)
-        self.relevant_features = df_bh.loc[df_bh.rejected].Feature
+        self.relevant_features = df_bh.loc[df_bh.rejected].Feature.tolist()
 
         return self
 
@@ -138,4 +139,4 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
         if isinstance(X, pd.DataFrame):
             return X.copy().loc[:, self.relevant_features]
         else:
-            return X[:, self.relevant_features.index]
+            return X[:, self.relevant_features]

--- a/tsfresh/transformers/feature_selector.py
+++ b/tsfresh/transformers/feature_selector.py
@@ -92,6 +92,8 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
         """
         self.relevant_features = None
         self.feature_importance_ = None
+        self.p_values = None
+
         self.test_for_binary_target_binary_feature = test_for_binary_target_binary_feature
         self.test_for_binary_target_real_feature = test_for_binary_target_real_feature
         self.test_for_real_target_binary_feature = test_for_real_target_binary_feature
@@ -131,6 +133,7 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
                                 self.test_for_binary_target_real_feature)
         self.relevant_features = df_bh.loc[df_bh.rejected].Feature.tolist()
         self.feature_importance_ = 1.0 - df_bh.p_value.values
+        self.p_values = df_bh.p_value.values
 
         return self
 

--- a/tsfresh/transformers/feature_selector.py
+++ b/tsfresh/transformers/feature_selector.py
@@ -82,6 +82,7 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
         :type chunksize: int
         """
         self.relevant_features = None
+        self.feature_importance_ = None
         self.test_for_binary_target_binary_feature = test_for_binary_target_binary_feature
         self.test_for_binary_target_real_feature = test_for_binary_target_real_feature
         self.test_for_real_target_binary_feature = test_for_real_target_binary_feature
@@ -120,6 +121,7 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
                                 self.fdr_level, self.hypotheses_independent,
                                 self.test_for_binary_target_real_feature)
         self.relevant_features = df_bh.loc[df_bh.rejected].Feature.tolist()
+        self.feature_importance_ = 1.0 - df_bh.p_value.values
 
         return self
 

--- a/tsfresh/transformers/feature_selector.py
+++ b/tsfresh/transformers/feature_selector.py
@@ -28,10 +28,19 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
     This estimator - as most of the sklearn estimators - works in a two step procedure. First, it is fitted
     on training data, where the target is known:
 
+    >>> import pandas as pd
     >>> X_train, y_train = pd.DataFrame(), pd.Series() # fill in with your features and target
     >>> from tsfresh.transformers import FeatureSelector
     >>> selector = FeatureSelector()
     >>> selector.fit(X_train, y_train)
+
+    In this example the list of relevant features is empty:
+    >>> selector.relevant_features
+    >>> []
+
+    The same holds for the feature importance:
+    >>> selector.feature_importance_
+    >>> array([], dtype=float64)
 
     The estimator keeps track on those features, that were relevant in the training step. If you
     apply the estimator after the training, it will delete all other features in the testing

--- a/tsfresh/transformers/feature_selector.py
+++ b/tsfresh/transformers/feature_selector.py
@@ -93,6 +93,7 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
         self.relevant_features = None
         self.feature_importances_ = None
         self.p_values = None
+        self.features = None
 
         self.test_for_binary_target_binary_feature = test_for_binary_target_binary_feature
         self.test_for_binary_target_real_feature = test_for_binary_target_real_feature
@@ -134,6 +135,7 @@ class FeatureSelector(BaseEstimator, TransformerMixin):
         self.relevant_features = df_bh.loc[df_bh.rejected].Feature.tolist()
         self.feature_importances_ = 1.0 - df_bh.p_value.values
         self.p_values = df_bh.p_value.values
+        self.features = df_bh.Feature.tolist()
 
         return self
 


### PR DESCRIPTION
* FeatureSelection().relevant_features is a DataFrame which contains the p-values of the selected features. 
* FeatureSelection().relevant_features.index holds the column names of the selected features.