### PR TITLE
Improve parallelization

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ The following chapters will explain the tsfresh package in detail:
    Feature Filtering <text/feature_filtering>
    How to write custom Feature Calculators <text/how_to_add_custom_feature>
    Feature Naming <text/feature_naming>
+   Parallelization <text/parallelization>
    FAQ <text/faq>
    Authors <authors>
    License <license>

--- a/docs/text/parallelization.rst
+++ b/docs/text/parallelization.rst
@@ -37,8 +37,8 @@ Additionally there are two options for how the parallelization is done:
 To enforce an option, either pass ``'per_kind'`` or ``'per_sample'`` as the ``parallelization=`` parameter of the
 :func:`tsfresh.extract_features` function. By default the option is chosen with a rule of thumb:
 
-If the number of different time series (kinds) is less than half the available worker processes (``n_processes``)
-then ``'per_sample'`` is chosen, otherwise ``'per_kind'``.
+If the number of different time series (kinds) is less than half of the number of available worker
+processes (``n_processes``) then ``'per_sample'`` is chosen, otherwise ``'per_kind'``.
 
 Generally, there is no perfect setting for all cases. On the one hand more parallelization can speed up the calculation
 as the work is better distributed among the computers resources. On the other hand parallelization

--- a/docs/text/parallelization.rst
+++ b/docs/text/parallelization.rst
@@ -31,13 +31,13 @@ for the feature selection.
 
 Additionally there are two options for how the parallelization is done:
 
-1.  ``'per_kind'`` parallelizes the feature calculation per kind of timeseries.
+1.  ``'per_kind'`` parallelizes the feature calculation per kind of time series.
 2.  ``'per_sample'`` parallelizes per kind and per sample.
 
 To enforce an option, either pass ``'per_kind'`` or ``'per_sample'`` as the ``parallelization=`` parameter of the
 :func:`tsfresh.extract_features` function. By default the option is chosen with a rule of thumb:
 
-If the number of different timeseries (kinds) is less than half the available worker processes (``n_processes``)
+If the number of different time series (kinds) is less than half the available worker processes (``n_processes``)
 then ``'per_sample'`` is chosen, otherwise ``'per_kind'``.
 
 Generally, there is no perfect setting for all cases. On the one hand more parallelization can speed up the calculation
@@ -50,7 +50,7 @@ Implementing the parallelization we observed the following points:
 -   For small data sets the difference between parallelization per kind or per sample should be negligible.
 -   For data sets with one kind of time series parallelization per sample results in a decent speed up that grows
     with the number of samples.
--   The more kinds of timeseries the data set contains, the more samples are necessary to make parallelization
+-   The more kinds of time series the data set contains, the more samples are necessary to make parallelization
     per sample worthwhile.
 -   If the data set contains more kinds of time series than available cpu cores, parallelization per kind is
     the way to go.

--- a/docs/text/parallelization.rst
+++ b/docs/text/parallelization.rst
@@ -1,0 +1,56 @@
+.. _parallelization-label:
+
+Parallelization
+===============
+
+The feature extraction as well as the feature selection offer the possibility of parallelization.
+Out of the box both tasks are parallelized by tsfresh. However, the overhead introduced with the
+parallelization should not be underestimated. Here we discuss the different settings to control
+the parallelization. To achieve best results for your use-case you should experiment with the parameters.
+
+Parallelization of Feature Selection
+------------------------------------
+
+We use a :class:`multiprocessing.Pool` to parallelize the calculation of the p-values for each feature. On
+instantiation we set the Pool's number of worker processes to
+:attr:`tsfresh.feature_selection.FeatureSignificanceTestsSettings.n_processes`. This field defaults to
+the number of processors on the current system. We recommend setting it to the maximum number of available (and
+otherwise idle) processors.
+
+The chunksize of the Pool's map function is another important parameter to consider. It can be set via the
+:attr:`tsfresh.feature_selection.FeatureSignificanceTestsSettings.chunksize` field. By default it is up to
+:class:`multiprocessing.Pool` to decide on the chunksize.
+
+Parallelization of Feature Extraction
+-------------------------------------
+
+For the feature extraction tsfresh exposes the parameters
+:attr:`tsfresh.feature_extraction.FeatureExtractionSettings.n_processes` and
+:attr:`tsfresh.feature_extraction.FeatureExtractionSettings.chunksize`. Both behave anlogue to the parameters
+for the feature selection.
+
+Additionally there are two options for how the parallelization is done:
+
+1.  ``'per_kind'`` parallelizes the feature calculation per kind of timeseries.
+2.  ``'per_sample'`` parallelizes per kind and per sample.
+
+To enforce an option, either pass ``'per_kind'`` or ``'per_sample'`` as the ``parallelization=`` parameter of the
+:func:`tsfresh.extract_features` function. By default the option is chosen with a rule of thumb:
+
+If the number of different timeseries (kinds) is less than half the available worker processes (``n_processes``)
+then ``'per_sample'`` is chosen, otherwise ``'per_kind'``.
+
+Generally, there is no perfect setting for all cases. On the one hand more parallelization can speed up the calculation
+as the work is better distributed among the computers resources. On the other hand parallelization
+introduces overheads such as copying data to the worker processes, splitting the data to enable the distribution and
+combining the results.
+
+Implementing the parallelization we observed the following points:
+
+-   For small data sets the difference between parallelization per kind or per sample should be negligible.
+-   For data sets with one kind of time series parallelization per sample results in a decent speed up that grows
+    with the number of samples.
+-   The more kinds of timeseries the data set contains, the more samples are necessary to make parallelization
+    per sample worthwhile.
+-   If the data set contains more kinds of time series than available cpu cores, parallelization per kind is
+    the way to go.

--- a/docs/text/parallelization.rst
+++ b/docs/text/parallelization.rst
@@ -8,6 +8,9 @@ Out of the box both tasks are parallelized by tsfresh. However, the overhead int
 parallelization should not be underestimated. Here we discuss the different settings to control
 the parallelization. To achieve best results for your use-case you should experiment with the parameters.
 
+Please let us know about your results tuning the below mentioned parameters! It will help improve this document as
+well as the default settings.
+
 Parallelization of Feature Selection
 ------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ statsmodels>=0.6.1
 patsy>=0.4.1
 scikit-learn>=0.17.1
 future>=0.16.0
+six>=1.10.0

--- a/tests/feature_extraction/test_extraction.py
+++ b/tests/feature_extraction/test_extraction.py
@@ -158,6 +158,20 @@ class ExtractionTestCase(DataTestCase):
         self.assertIn("value1__maximum", list(X.columns))
         self.assertIn("value2__maximum", list(X.columns))
 
+    def test_extract_features_per_sample_equals_per_kind(self):
+        df = self.create_test_data_sample()
+
+        features_per_sample = extract_features(df, self.settings, "id", "sort", "kind", "val",
+                                               parallelization='per_sample')
+        features_per_kind = extract_features(df, self.settings, "id", "sort", "kind", "val",
+                                               parallelization='per_kind')
+
+        six.assertCountEqual(self, features_per_sample.columns, features_per_kind.columns)
+
+        for col in features_per_sample.columns:
+            self.assertIsNone(np.testing.assert_array_almost_equal(features_per_sample[col],
+                                                                   features_per_kind[col]))
+
 
 class ParallelExtractionTestCase(DataTestCase):
     def setUp(self):

--- a/tests/feature_extraction/test_extraction.py
+++ b/tests/feature_extraction/test_extraction.py
@@ -11,7 +11,7 @@ from tsfresh.feature_extraction.settings import FeatureExtractionSettings
 import six
 import os
 
-class FeatureExtractorTestCase(DataTestCase):
+class ExtractionTestCase(DataTestCase):
     """The unit tests in this module make sure if the time series features are created properly"""
 
     def setUp(self):
@@ -19,7 +19,7 @@ class FeatureExtractorTestCase(DataTestCase):
         self.settings.PROFILING = False
         self.settings.n_processes = 1
 
-    def test_calculate_ts_features_per_kind(self):
+    def test_extract_features_per_kind(self):
         # todo: implement more methods and test more aspects
         df = self.create_test_data_sample()
         extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val",
@@ -44,7 +44,7 @@ class FeatureExtractorTestCase(DataTestCase):
         self.assertTrue(np.all(extracted_features_sts.a__sum_values == np.array([1.0, 11.0])))
         self.assertTrue(np.all(extracted_features_sts.a__count_above_mean == np.array([0, 1])))
 
-    def test_calculate_ts_features_per_sample(self):
+    def test_extract_features_per_sample(self):
         # todo: implement more methods and test more aspects
         df = self.create_test_data_sample()
         extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val",
@@ -69,7 +69,7 @@ class FeatureExtractorTestCase(DataTestCase):
         self.assertTrue(np.all(extracted_features_sts.a__sum_values == np.array([1.0, 11.0])))
         self.assertTrue(np.all(extracted_features_sts.a__count_above_mean == np.array([0, 1])))
 
-    def test_calculate_ts_features_for_one_time_series(self):
+    def test_extract_features_for_one_time_series(self):
         # todo: implement more methods and test more aspects
         df = self.create_test_data_sample()
         extracted_features = _extract_features_for_one_time_series(["b", df.loc[df.kind == "b", ["val", "id"]]],
@@ -93,7 +93,7 @@ class FeatureExtractorTestCase(DataTestCase):
         self.assertTrue(np.all(extracted_features_sts.a__sum_values == np.array([1.0, 11.0])))
         self.assertTrue(np.all(extracted_features_sts.a__count_above_mean == np.array([0, 1])))
 
-    def test_calculate_ts_features_after_randomisation(self):
+    def test_extract_features_after_randomisation(self):
         df = self.create_test_data_sample()
         df_random = df.copy().sample(frac=1)
 
@@ -132,7 +132,7 @@ class FeatureExtractorTestCase(DataTestCase):
         self.assertTrue(os.path.isfile(fes.PROFILING_FILENAME))
         os.remove(fes.PROFILING_FILENAME)
 
-    def test_extracting_without_settings(self):
+    def test_extract_features_without_settings(self):
         df = pd.DataFrame(data={"id": np.repeat([1, 2], 10),
                                 "value1": np.random.normal(0, 1, 20),
                                 "value2": np.random.normal(0, 1, 20)})
@@ -141,7 +141,7 @@ class FeatureExtractorTestCase(DataTestCase):
         self.assertIn("value2__maximum", list(X.columns))
 
 
-class ParallelFeatureExtractorTestCase(DataTestCase):
+class ParallelExtractionTestCase(DataTestCase):
     def setUp(self):
         self.settings = FeatureExtractionSettings()
         self.settings.PROFILING = False
@@ -155,7 +155,7 @@ class ParallelFeatureExtractorTestCase(DataTestCase):
                               "mean": None,
                               "median": None}
 
-    def test_calculate_ts_features(self):
+    def test_extract_features(self):
         # todo: implement more methods and test more aspects
         df = self.create_test_data_sample()
         extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val")

--- a/tests/feature_extraction/test_extraction.py
+++ b/tests/feature_extraction/test_extraction.py
@@ -93,13 +93,31 @@ class ExtractionTestCase(DataTestCase):
         self.assertTrue(np.all(extracted_features_sts.a__sum_values == np.array([1.0, 11.0])))
         self.assertTrue(np.all(extracted_features_sts.a__count_above_mean == np.array([0, 1])))
 
-    def test_extract_features_after_randomisation(self):
+    def test_extract_features_after_randomisation_per_kind(self):
         df = self.create_test_data_sample()
         df_random = df.copy().sample(frac=1)
 
-        extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val").sort_index()
+        extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val",
+                                              parallelization='per_kind').sort_index()
         extracted_features_from_random = extract_features(df_random, self.settings,
-                                                          "id", "sort", "kind", "val").sort_index()
+                                                          "id", "sort", "kind", "val",
+                                                          parallelization='per_kind').sort_index()
+
+        six.assertCountEqual(self, extracted_features.columns, extracted_features_from_random.columns)
+
+        for col in extracted_features:
+            self.assertIsNone(np.testing.assert_array_almost_equal(extracted_features[col],
+                                                                   extracted_features_from_random[col]))
+
+    def test_extract_features_after_randomisation_per_sample(self):
+        df = self.create_test_data_sample()
+        df_random = df.copy().sample(frac=1)
+
+        extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val",
+                                              parallelization='per_sample').sort_index()
+        extracted_features_from_random = extract_features(df_random, self.settings,
+                                                          "id", "sort", "kind", "val",
+                                                          parallelization='per_sample').sort_index()
 
         six.assertCountEqual(self, extracted_features.columns, extracted_features_from_random.columns)
 

--- a/tests/feature_extraction/test_ts_features.py
+++ b/tests/feature_extraction/test_ts_features.py
@@ -107,36 +107,6 @@ class FeatureExtractorTestCase(DataTestCase):
             self.assertIsNone(np.testing.assert_array_almost_equal(extracted_features[col],
                                                                    extracted_features_from_random[col]))
 
-    class ParallelFeatureExtractorTestCase(DataTestCase):
-        def setUp(self):
-            self.settings = FeatureExtractionSettings()
-            self.settings.PROFILING = False
-            self.settings.n_processes = 2
-
-            # only calculate some features to reduce load on travis ci
-            self.name_to_param = {"maximum": None,
-                                  "sum_values": None,
-                                  "abs_energy": None,
-                                  "minimum": None,
-                                  "mean": None,
-                                  "median": None}
-
-        def test_calculate_ts_features(self):
-            # todo: implement more methods and test more aspects
-            df = self.create_test_data_sample()
-            extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val")
-
-            self.assertIsInstance(extracted_features, pd.DataFrame)
-            self.assertTrue(np.all(extracted_features.a__maximum == np.array([71, 77])))
-            self.assertTrue(np.all(extracted_features.a__sum_values == np.array([691, 1017])))
-            self.assertTrue(np.all(extracted_features.a__abs_energy == np.array([32211, 63167])))
-            self.assertTrue(np.all(extracted_features.b__sum_values == np.array([757, 695])))
-            self.assertTrue(np.all(extracted_features.b__minimum == np.array([3, 1])))
-            self.assertTrue(np.all(extracted_features.b__abs_energy == np.array([36619, 35483])))
-            self.assertTrue(np.all(extracted_features.b__mean == np.array([37.85, 34.75])))
-            self.assertTrue(np.all(extracted_features.b__median == np.array([39.5, 28.0])))
-            
-
     def test_profiling_file_written_out(self):
 
         fes = FeatureExtractionSettings()
@@ -170,3 +140,32 @@ class FeatureExtractorTestCase(DataTestCase):
         self.assertIn("value1__maximum", list(X.columns))
         self.assertIn("value2__maximum", list(X.columns))
 
+
+class ParallelFeatureExtractorTestCase(DataTestCase):
+    def setUp(self):
+        self.settings = FeatureExtractionSettings()
+        self.settings.PROFILING = False
+        self.settings.n_processes = 2
+
+        # only calculate some features to reduce load on travis ci
+        self.name_to_param = {"maximum": None,
+                              "sum_values": None,
+                              "abs_energy": None,
+                              "minimum": None,
+                              "mean": None,
+                              "median": None}
+
+    def test_calculate_ts_features(self):
+        # todo: implement more methods and test more aspects
+        df = self.create_test_data_sample()
+        extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val")
+
+        self.assertIsInstance(extracted_features, pd.DataFrame)
+        self.assertTrue(np.all(extracted_features.a__maximum == np.array([71, 77])))
+        self.assertTrue(np.all(extracted_features.a__sum_values == np.array([691, 1017])))
+        self.assertTrue(np.all(extracted_features.a__abs_energy == np.array([32211, 63167])))
+        self.assertTrue(np.all(extracted_features.b__sum_values == np.array([757, 695])))
+        self.assertTrue(np.all(extracted_features.b__minimum == np.array([3, 1])))
+        self.assertTrue(np.all(extracted_features.b__abs_energy == np.array([36619, 35483])))
+        self.assertTrue(np.all(extracted_features.b__mean == np.array([37.85, 34.75])))
+        self.assertTrue(np.all(extracted_features.b__median == np.array([39.5, 28.0])))

--- a/tests/feature_extraction/test_ts_features.py
+++ b/tests/feature_extraction/test_ts_features.py
@@ -19,10 +19,11 @@ class FeatureExtractorTestCase(DataTestCase):
         self.settings.PROFILING = False
         self.settings.n_processes = 1
 
-    def test_calculate_ts_features(self):
+    def test_calculate_ts_features_per_kind(self):
         # todo: implement more methods and test more aspects
         df = self.create_test_data_sample()
-        extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val")
+        extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val",
+                                              parallelization='per_kind')
 
         self.assertIsInstance(extracted_features, pd.DataFrame)
         self.assertTrue(np.all(extracted_features.a__maximum == np.array([71, 77])))
@@ -35,7 +36,33 @@ class FeatureExtractorTestCase(DataTestCase):
         self.assertTrue(np.all(extracted_features.b__median == np.array([39.5, 28.0])))
 
         df_sts = self.create_one_valued_time_series()
-        extracted_features_sts = extract_features(df_sts, self.settings, "id", "sort", "kind", "val")
+        extracted_features_sts = extract_features(df_sts, self.settings, "id", "sort", "kind", "val",
+                                                  parallelization='per_kind')
+
+        self.assertIsInstance(extracted_features_sts, pd.DataFrame)
+        self.assertTrue(np.all(extracted_features_sts.a__maximum == np.array([1.0, 6.0])))
+        self.assertTrue(np.all(extracted_features_sts.a__sum_values == np.array([1.0, 11.0])))
+        self.assertTrue(np.all(extracted_features_sts.a__count_above_mean == np.array([0, 1])))
+
+    def test_calculate_ts_features_per_sample(self):
+        # todo: implement more methods and test more aspects
+        df = self.create_test_data_sample()
+        extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val",
+                                              parallelization='per_sample')
+
+        self.assertIsInstance(extracted_features, pd.DataFrame)
+        self.assertTrue(np.all(extracted_features.a__maximum == np.array([71, 77])))
+        self.assertTrue(np.all(extracted_features.a__sum_values == np.array([691, 1017])))
+        self.assertTrue(np.all(extracted_features.a__abs_energy == np.array([32211, 63167])))
+        self.assertTrue(np.all(extracted_features.b__sum_values == np.array([757, 695])))
+        self.assertTrue(np.all(extracted_features.b__minimum == np.array([3, 1])))
+        self.assertTrue(np.all(extracted_features.b__abs_energy == np.array([36619, 35483])))
+        self.assertTrue(np.all(extracted_features.b__mean == np.array([37.85, 34.75])))
+        self.assertTrue(np.all(extracted_features.b__median == np.array([39.5, 28.0])))
+
+        df_sts = self.create_one_valued_time_series()
+        extracted_features_sts = extract_features(df_sts, self.settings, "id", "sort", "kind", "val",
+                                                  parallelization='per_sample')
 
         self.assertIsInstance(extracted_features_sts, pd.DataFrame)
         self.assertTrue(np.all(extracted_features_sts.a__maximum == np.array([1.0, 6.0])))

--- a/tests/feature_extraction/test_ts_features.py
+++ b/tests/feature_extraction/test_ts_features.py
@@ -101,22 +101,6 @@ class FeatureExtractorTestCase(DataTestCase):
         extracted_features_from_random = extract_features(df_random, self.settings,
                                                           "id", "sort", "kind", "val").sort_index()
 
-
-        six.assertCountEqual(self, extracted_features.columns, extracted_features_from_random.columns)
-
-        for col in extracted_features:
-            self.assertIsNone(np.testing.assert_array_almost_equal(extracted_features[col],
-                                                                   extracted_features_from_random[col]))
-
-    def test_calculate_ts_features_after_randomisation(self):
-        df = self.create_test_data_sample()
-        df_random = df.copy().sample(frac=1)
-
-        extracted_features = extract_features(df, self.settings, "id", "sort", "kind", "val").sort_index()
-        extracted_features_from_random = extract_features(df_random, self.settings,
-                                                          "id", "sort", "kind", "val").sort_index()
-
-
         six.assertCountEqual(self, extracted_features.columns, extracted_features_from_random.columns)
 
         for col in extracted_features:

--- a/tests/feature_selection/test_feature_selectors.py
+++ b/tests/feature_selection/test_feature_selectors.py
@@ -38,8 +38,7 @@ class FeatureSelection(TestCase):
         p_value = tsfresh.feature_selection.significance_tests.target_binary_feature_binary_test(x, y)
         self.assertGreater(p_value, self.minimal_p_value_for_unsignificant_features)
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, True)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, True)
         self.assertEqual(result_series.name, "TEST")
         self.assertGreater(result_series.p_value, self.minimal_p_value_for_unsignificant_features)
         self.assertEqual(result_series.type, "binary")
@@ -54,8 +53,7 @@ class FeatureSelection(TestCase):
 
         self.assertGreater(p_value, self.minimal_p_value_for_unsignificant_features)
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, True)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, True)
         self.assertEqual(result_series.name, "TEST")
         self.assertGreater(result_series.p_value, self.minimal_p_value_for_unsignificant_features)
         self.assertEqual(result_series.type, "real")
@@ -70,8 +68,7 @@ class FeatureSelection(TestCase):
 
         self.assertGreater(p_value, self.minimal_p_value_for_unsignificant_features)
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, False)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, False)
         self.assertEqual(result_series.name, "TEST")
         self.assertGreater(result_series.p_value, self.minimal_p_value_for_unsignificant_features)
         self.assertEqual(result_series.type, "binary")
@@ -86,8 +83,7 @@ class FeatureSelection(TestCase):
 
         self.assertGreater(p_value, self.minimal_p_value_for_unsignificant_features)
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, False)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, False)
         self.assertEqual(result_series.name, "TEST")
         self.assertGreater(result_series.p_value, self.minimal_p_value_for_unsignificant_features)
         self.assertEqual(result_series.type, "real")
@@ -104,8 +100,7 @@ class FeatureSelection(TestCase):
         p_value = tsfresh.feature_selection.significance_tests.target_binary_feature_binary_test(x, y)
         self.assertLess(p_value, self.maximal_p_value_for_significant_features)
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, True)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, True)
         self.assertEqual(result_series.name, "TEST")
         self.assertLess(result_series.p_value, self.maximal_p_value_for_significant_features)
         self.assertEqual(result_series.type, "binary")
@@ -124,8 +119,7 @@ class FeatureSelection(TestCase):
         p_value = tsfresh.feature_selection.significance_tests.target_binary_feature_real_test(x, y, self.settings)
         self.assertLess(p_value, self.maximal_p_value_for_significant_features)
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, True)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, True)
         self.assertEqual(result_series.name, "TEST")
         self.assertLess(result_series.p_value, self.maximal_p_value_for_significant_features)
         self.assertEqual(result_series.type, "real")
@@ -147,8 +141,7 @@ class FeatureSelection(TestCase):
         p_value = tsfresh.feature_selection.significance_tests.target_binary_feature_real_test(x, y, tmp_settings)
         self.assertLess(p_value, self.maximal_p_value_for_significant_features)
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, True)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, True)
         self.assertEqual(result_series.name, "TEST")
         self.assertLess(result_series.p_value, self.maximal_p_value_for_significant_features)
         self.assertEqual(result_series.type, "real")
@@ -162,8 +155,7 @@ class FeatureSelection(TestCase):
         p_value = tsfresh.feature_selection.significance_tests.target_real_feature_binary_test(x, y)
         self.assertLess(p_value, self.maximal_p_value_for_significant_features)
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, False)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, False)
         self.assertEqual(result_series.name, "TEST")
         self.assertLess(result_series.p_value, self.maximal_p_value_for_significant_features)
         self.assertEqual(result_series.type, "binary")
@@ -178,8 +170,7 @@ class FeatureSelection(TestCase):
 
         self.assertLess(p_value, self.maximal_p_value_for_significant_features)
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, False)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, False)
         self.assertEqual(result_series.name, "TEST")
         self.assertLess(result_series.p_value, self.maximal_p_value_for_significant_features)
         self.assertEqual(result_series.type, "real")
@@ -189,8 +180,7 @@ class FeatureSelection(TestCase):
         x = pd.Series([1.111]*250, name="TEST")
         y = x + pd.Series(np.random.normal(0, 1, 250))
 
-        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value("TEST", pd.DataFrame(x), y,
-                                                                                      self.settings, False)
+        result_series = tsfresh.feature_selection.feature_selector._calculate_p_value(x, y, self.settings, False)
         self.assertEqual(result_series.name, "TEST")
         self.assertEqual(result_series.type, "const")
         self.assertEqual(result_series.rejected, False)

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -124,9 +124,8 @@ def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, col
     """
     Parallelize the feature extraction per kind.
 
-    :param timeseries_container: The pandas.DataFrame with the time series to compute the features for, or a
-               dictionary of pandas.DataFrames.
-    :type timeseries_container: pandas.DataFrame or dict
+    :param kind_to_df_map: The time series to compute the features for in our internal format
+    :type kind_to_df_map: dict of pandas.DataFrame
 
     :param column_id: The name of the id column to group by.
     :type column_id: str

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -198,7 +198,7 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
         results_fifo.put(
             pool.map_async(
                 partial_extract_features_for_one_time_series,
-                [(kind, df_group) for _, df_group in df_grouped_by_id],
+                [(kind, df_group.astype(np.float64)) for _, df_group in df_grouped_by_id],
                 chunksize=settings.chunksize
             )
         )
@@ -210,7 +210,7 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
     while not results_fifo.empty():
         map_result = results_fifo.get()
         dfs = map_result.get()
-        dfs_per_kind.append(pd.concat(dfs, axis=0))
+        dfs_per_kind.append(pd.concat(dfs, axis=0).astype(np.float64))
 
     result = pd.concat(dfs_per_kind, axis=1).astype(np.float64)
 

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -67,7 +67,10 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
     :param column_value: The name for the column keeping the value itself.
     :type column_value: str
 
-    :param parallelization: Either 'per_sample' or 'per_kind'
+    :param parallelization: Either ``'per_sample'`` or ``'per_kind'``   , see
+                            :func:`~tsfresh.feature_extraction.extraction._extract_features_parallel_per_sample`,
+                            :func:`~tsfresh.feature_extraction.extraction._extract_features_parallel_per_kind` and
+                            :ref:`parallelization-label` for details.
     :type parallelization: str
 
     :return: The (maybe imputed) DataFrame containing extracted features.

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -146,7 +146,8 @@ def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, col
                                                            settings=settings)
     pool = Pool(settings.n_processes)
 
-    extracted_features = pool.map(partial_extract_features_for_one_time_series, kind_to_df_map.items())
+    extracted_features = pool.map(partial_extract_features_for_one_time_series, kind_to_df_map.items(),
+                                  chunksize=settings.chunksize)
 
     pool.close()
 
@@ -193,7 +194,8 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
         results_fifo.put(
             pool.map_async(
                 partial_extract_features_for_one_time_series,
-                [(kind, group) for _, group in gb]
+                [(kind, group) for _, group in gb],
+                chunksize=settings.chunksize
             )
         )
 

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division
 from builtins import str
 from multiprocessing import Pool
 from functools import partial
-from Queue import Queue
+from six.moves.queue import Queue
 import pandas as pd
 import numpy as np
 
@@ -189,7 +189,7 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
 
     # Submit map jobs per kind per sample
     results_fifo = Queue()
-    for kind, df_kind in kind_to_df_map.iteritems():
+    for kind, df_kind in kind_to_df_map.items():
         gb = df_kind.groupby(column_id)
         results_fifo.put(
             pool.map_async(

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -202,11 +202,11 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
     # Submit map jobs per kind per sample
     results_fifo = Queue()
     for kind, df_kind in kind_to_df_map.items():
-        gb = df_kind.groupby(column_id)
+        df_grouped_by_id = df_kind.groupby(column_id)
         results_fifo.put(
             pool.map_async(
                 partial_extract_features_for_one_time_series,
-                [(kind, group) for _, group in gb],
+                [(kind, df_group) for _, df_group in df_grouped_by_id],
                 chunksize=settings.chunksize
             )
         )

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -144,10 +144,6 @@ def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, col
     :return: The (maybe imputed) DataFrame containing extracted features.
     :rtype: pandas.DataFrame
     """
-    all_possible_unique_id_values = set(id_value for kind, df in kind_to_df_map.items()
-                                        for id_value in df[column_id])
-    df_with_ids = pd.DataFrame(index=all_possible_unique_id_values)
-
     partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
                                                            column_id=column_id,
                                                            column_value=column_value,
@@ -160,8 +156,7 @@ def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, col
     pool.close()
 
     # Concatenate all partial results
-    result = pd.concat([df_with_ids] + extracted_features, axis=1, join='outer', join_axes=[df_with_ids.index]) \
-        .astype(np.float64)
+    result = pd.concat(extracted_features, axis=1, join='outer').astype(np.float64)
 
     pool.join()
     return result
@@ -189,10 +184,6 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
     :return: The (maybe imputed) DataFrame containing extracted features.
     :rtype: pandas.DataFrame
     """
-    all_possible_unique_id_values = set(id_value for kind, df in kind_to_df_map.items()
-                                        for id_value in df[column_id])
-    df_with_ids = pd.DataFrame(index=all_possible_unique_id_values)
-
     partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
                                                            column_id=column_id,
                                                            column_value=column_value,
@@ -214,7 +205,7 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
     pool.close()
 
     # Wait for the jobs to complete and concatenate the partial results
-    dfs_per_kind = [df_with_ids]
+    dfs_per_kind = []
     while not results_fifo.empty():
         map_result = results_fifo.get()
         dfs = map_result.get()

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -11,11 +11,16 @@ from builtins import str
 from multiprocessing import Pool
 from functools import partial
 from six.moves.queue import Queue
+import logging
 import pandas as pd
 import numpy as np
 
 from tsfresh.utilities import dataframe_functions, profiling
 from tsfresh.feature_extraction.settings import FeatureExtractionSettings
+
+
+_logger = logging.getLogger(__name__)
+
 
 def extract_features(timeseries_container, feature_extraction_settings=None,
                      column_id=None, column_sort=None, column_kind=None, column_value=None,
@@ -93,6 +98,7 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
         parallelization = 'per_sample'
     else:
         parallelization = 'per_kind'
+    _logger.info('Parallelizing feature calculation {}'.format(parallelization))
 
     # If requested, do profiling (advanced feature)
     if feature_extraction_settings.PROFILING:

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -198,7 +198,7 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
         results_fifo.put(
             pool.map_async(
                 partial_extract_features_for_one_time_series,
-                [(kind, df_group.astype(np.float64)) for _, df_group in df_grouped_by_id],
+                [(kind, df_group) for _, df_group in df_grouped_by_id],
                 chunksize=settings.chunksize
             )
         )
@@ -280,6 +280,9 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
     """
     column_prefix, dataframe = prefix_and_dataframe
     column_prefix = str(column_prefix)
+
+    # Ensure features are calculated on float64
+    dataframe[column_value] = dataframe[column_value].astype(np.float64)
 
     with warnings.catch_warnings():
         if not settings.show_warnings:

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -204,7 +204,7 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
 
     pool.close()
 
-    # Wait for the jobs to complete and conatenate the partial results
+    # Wait for the jobs to complete and concatenate the partial results
     dfs_per_kind = [df_with_ids]
     while not results_fifo.empty():
         map_result = results_fifo.get()

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -94,10 +94,10 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
             feature_extraction_settings.set_default_parameters(key)
 
     # Choose the parallelization according to a rule-of-thumb
-    if parallelization is None and (feature_extraction_settings.n_processes / 2) > len(kind_to_df_map):
-        parallelization = 'per_sample'
-    else:
-        parallelization = 'per_kind'
+    if parallelization is None:
+        parallelization = 'per_sample' if (feature_extraction_settings.n_processes / 2) > len(kind_to_df_map) \
+            else 'per_kind'
+
     _logger.info('Parallelizing feature calculation {}'.format(parallelization))
 
     # If requested, do profiling (advanced feature)

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -171,6 +171,10 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
     """
     Parallelize the feature extraction per kind and per sample.
 
+    As the splitting of the dataframes per kind along column_id is quite costly, we settled for an async map in this
+    function. The result objects are temporarily stored in a fifo queue from which they can be retrieved in order
+    of submission.
+
     :param kind_to_df_map: The time series to compute the features for in our internal format
     :type kind_to_df_map: dict of pandas.DataFrame
 

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -6,16 +6,20 @@ This module contains the main function to interact with tsfresh: extract feature
 """
 
 from __future__ import absolute_import, division
+
 from builtins import str
 from multiprocessing import Pool
 from functools import partial
+from Queue import Queue
 import pandas as pd
 import numpy as np
+
 from tsfresh.utilities import dataframe_functions, profiling
 from tsfresh.feature_extraction.settings import FeatureExtractionSettings
 
 def extract_features(timeseries_container, feature_extraction_settings=None,
-                     column_id=None, column_sort=None, column_kind=None, column_value=None):
+                     column_id=None, column_sort=None, column_kind=None, column_value=None,
+                     parallelization=None):
     """
     Extract features from
 
@@ -48,22 +52,27 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
             dictionary of pandas.DataFrames.
     :type timeseries_container: pandas.DataFrame or dict
 
-    :param column_id: The name of the id column to group by.
-    :type column_id: str
-    :param column_sort: The name of the sort column.
-    :type column_sort: str
-    :param column_kind: The name of the column keeping record on the kind of the value.
-    :type column_kind: str
-    :param column_value: The name for the column keeping the value itself.
-    :type column_value: str
-
     :param feature_extraction_settings: settings object that controls which features are calculated
     :type feature_extraction_settings: tsfresh.feature_extraction.settings.FeatureExtractionSettings
 
-    :return: The (maybe imputed) DataFrame with the extracted features.
+    :param column_id: The name of the id column to group by.
+    :type column_id: str
+
+    :param column_sort: The name of the sort column.
+    :type column_sort: str
+
+    :param column_kind: The name of the column keeping record on the kind of the value.
+    :type column_kind: str
+
+    :param column_value: The name for the column keeping the value itself.
+    :type column_value: str
+
+    :param parallelization: Either 'per_sample' or 'per_kind'
+    :type parallelization: str
+
+    :return: The (maybe imputed) DataFrame containing extracted features.
     :rtype: pandas.DataFrame
     """
-
     # Always use the standardized way of storing the data.
     # See the function normalize_input_to_internal_representation for more information.
     kind_to_df_map, column_id, column_value = \
@@ -76,23 +85,25 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
         for key in kind_to_df_map:
             feature_extraction_settings.set_default_parameters(key)
 
+    # Choose the parallelization according to a rule-of-thumb
+    if parallelization is None and (feature_extraction_settings.n_processes / 2) > len(kind_to_df_map):
+        parallelization = 'per_sample'
+    else:
+        parallelization = 'per_kind'
+
     # If requested, do profiling (advanced feature)
     if feature_extraction_settings.PROFILING:
         profiler = profiling.start_profiling()
 
-    # Extract the time series features for every type of time series and concatenate them together.
-    all_possible_unique_id_values = set(id_value for kind, df in kind_to_df_map.items()
-                                        for id_value in df[column_id])
-    df_with_ids = pd.DataFrame(index=all_possible_unique_id_values)
-
-    pool = Pool(feature_extraction_settings.n_processes)
-    partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series, column_id=column_id,
-                              column_value=column_value, settings=feature_extraction_settings)
-    extracted_features = pool.map(partial_extract_features_for_one_time_series, kind_to_df_map.items())
-
-    # Add time series features to result
-    result = pd.concat([df_with_ids] + extracted_features, axis=1, join='outer', join_axes=[df_with_ids.index])\
-        .astype(np.float64)
+    # Calculate the result
+    if parallelization == 'per_kind':
+        result = _extract_features_parallel_per_kind(kind_to_df_map, feature_extraction_settings,
+                                                     column_id, column_value)
+    elif parallelization == 'per_sample':
+        result = _extract_features_parallel_per_sample(kind_to_df_map, feature_extraction_settings,
+                                                       column_id, column_value)
+    else:
+        raise ValueError("Argument parallelization must be one of: 'per_kind', 'per_sample'")
 
     # Impute the result if requested
     if feature_extraction_settings.IMPUTE is not None:
@@ -103,9 +114,101 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
         profiling.end_profiling(profiler, filename=feature_extraction_settings.PROFILING_FILENAME,
                                 sorting=feature_extraction_settings.PROFILING_SORTING)
 
-    pool.close()
-    pool.join()
+    return result
 
+
+def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, column_value):
+    """
+    Parallelize the feature extraction per kind.
+
+    :param timeseries_container: The pandas.DataFrame with the time series to compute the features for, or a
+               dictionary of pandas.DataFrames.
+    :type timeseries_container: pandas.DataFrame or dict
+
+    :param column_id: The name of the id column to group by.
+    :type column_id: str
+    :param column_value: The name for the column keeping the value itself.
+    :type column_value: str
+
+    :param settings: settings object that controls which features are calculated
+    :type settings: tsfresh.feature_extraction.settings.FeatureExtractionSettings
+
+    :return: The (maybe imputed) DataFrame containing extracted features.
+    :rtype: pandas.DataFrame
+    """
+    all_possible_unique_id_values = set(id_value for kind, df in kind_to_df_map.items()
+                                        for id_value in df[column_id])
+    df_with_ids = pd.DataFrame(index=all_possible_unique_id_values)
+
+    partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
+                                                           column_id=column_id,
+                                                           column_value=column_value,
+                                                           settings=settings)
+    pool = Pool(settings.n_processes)
+
+    extracted_features = pool.map(partial_extract_features_for_one_time_series, kind_to_df_map.items())
+
+    pool.close()
+
+    # Concatenate all partial results
+    result = pd.concat([df_with_ids] + extracted_features, axis=1, join='outer', join_axes=[df_with_ids.index]) \
+        .astype(np.float64)
+
+    pool.join()
+    return result
+
+
+def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, column_value):
+    """
+    Parallelize the feature extraction per kind and per sample.
+
+    :param kind_to_df_map: The time series to compute the features for in our internal format
+    :type kind_to_df_map: dict of pandas.DataFrame
+
+    :param column_id: The name of the id column to group by.
+    :type column_id: str
+    :param column_value: The name for the column keeping the value itself.
+    :type column_value: str
+
+    :param settings: settings object that controls which features are calculated
+    :type settings: tsfresh.feature_extraction.settings.FeatureExtractionSettings
+
+    :return: The (maybe imputed) DataFrame containing extracted features.
+    :rtype: pandas.DataFrame
+    """
+    all_possible_unique_id_values = set(id_value for kind, df in kind_to_df_map.items()
+                                        for id_value in df[column_id])
+    df_with_ids = pd.DataFrame(index=all_possible_unique_id_values)
+
+    partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
+                                                           column_id=column_id,
+                                                           column_value=column_value,
+                                                           settings=settings)
+    pool = Pool(settings.n_processes)
+
+    # Submit map jobs per kind per sample
+    results_fifo = Queue()
+    for kind, df_kind in kind_to_df_map.iteritems():
+        gb = df_kind.groupby(column_id)
+        results_fifo.put(
+            pool.map_async(
+                partial_extract_features_for_one_time_series,
+                [(kind, group) for _, group in gb]
+            )
+        )
+
+    pool.close()
+
+    # Wait for the jobs to complete and conatenate the partial results
+    dfs_per_kind = [df_with_ids]
+    while not results_fifo.empty():
+        map_result = results_fifo.get()
+        dfs = map_result.get()
+        dfs_per_kind.append(pd.concat(dfs, axis=0))
+
+    result = pd.concat(dfs_per_kind, axis=1).astype(np.float64)
+
+    pool.join()
     return result
 
 

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -103,6 +103,9 @@ class FeatureExtractionSettings(object):
         n_cores = int(os.getenv("NUMBER_OF_CPUS") or cpu_count())
         self.n_processes = max(1, n_cores//2)
 
+        # Size of the chunks submitted to the worker processes
+        self.chunksize = None
+
     def set_default_parameters(self, kind):
         """
         Setup the feature calculations for kind as defined in `self.name_to_param`

--- a/tsfresh/feature_selection/feature_selector.py
+++ b/tsfresh/feature_selection/feature_selector.py
@@ -116,7 +116,8 @@ def check_fs_sig_bh(X, y, settings=None):
 
     # Helper function which wrapps the _calculate_p_value with many arguments already set
     f = partial(_calculate_p_value, X=X, y=y, settings=settings, target_is_binary=target_is_binary)
-    p_values_of_features = pd.DataFrame(pool.map(f, df_features['Feature']))
+    results = pool.map(f, df_features['Feature'], chunksize=settings.chunksize)
+    p_values_of_features = pd.DataFrame(results)
     df_features.update(p_values_of_features)
 
     pool.close()

--- a/tsfresh/feature_selection/feature_selector.py
+++ b/tsfresh/feature_selection/feature_selector.py
@@ -116,7 +116,7 @@ def check_fs_sig_bh(X, y, settings=None):
 
     # Helper function which wrapps the _calculate_p_value with many arguments already set
     f = partial(_calculate_p_value, y=y, settings=settings, target_is_binary=target_is_binary)
-    results = pool.map(f, [X[column] for column in set(X.columns)], chunksize=settings.chunksize)
+    results = pool.map(f, [X[feature] for feature in df_features['Feature']], chunksize=settings.chunksize)
     p_values_of_features = pd.DataFrame(results)
     df_features.update(p_values_of_features)
 

--- a/tsfresh/feature_selection/feature_selector.py
+++ b/tsfresh/feature_selection/feature_selector.py
@@ -115,8 +115,8 @@ def check_fs_sig_bh(X, y, settings=None):
     pool = Pool(settings.n_processes)
 
     # Helper function which wrapps the _calculate_p_value with many arguments already set
-    f = partial(_calculate_p_value, X=X, y=y, settings=settings, target_is_binary=target_is_binary)
-    results = pool.map(f, df_features['Feature'], chunksize=settings.chunksize)
+    f = partial(_calculate_p_value, y=y, settings=settings, target_is_binary=target_is_binary)
+    results = pool.map(f, [X[column] for column in set(X.columns)], chunksize=settings.chunksize)
     p_values_of_features = pd.DataFrame(results)
     df_features.update(p_values_of_features)
 
@@ -146,19 +146,16 @@ def check_fs_sig_bh(X, y, settings=None):
     return df_features
 
 
-def _calculate_p_value(feature, X, y, settings, target_is_binary):
+def _calculate_p_value(feature_column, y, settings, target_is_binary):
     """
-    Internal helper function to calculate the p-value of a given feature in df_features using one of the dedicated
-    functions target_*_feature_*_test. It uses the data in X and the target in y.
+    Internal helper function to calculate the p-value of a given feature using one of the dedicated
+    functions target_*_feature_*_test.
 
-    :param X: the data with a column named after feature.
-    :type X: pandas.DataFrame
+    :param feature_column: the feature column.
+    :type feature_column: pandas.Series
 
     :param y: the binary target vector
     :type y: pandas.Series
-
-    :param feature: The feature for which the p-value should be calculated.
-    :type feature: basestring
 
     :param settings: The settings object to control how the significance is calculated.
     :type settings: FeatureSignificanceTestsSettings
@@ -171,29 +168,29 @@ def _calculate_p_value(feature, X, y, settings, target_is_binary):
     :rtype: pd.Series
     """
     # Do not process constant features
-    if len(pd.unique(X[feature].values)) == 1:
-        _logger.warning("[test_feature_significance] Feature {} is constant".format(feature))
-        return pd.Series({"type": "const", "rejected": False}, name=feature)
+    if len(pd.unique(feature_column.values)) == 1:
+        _logger.warning("[test_feature_significance] Feature {} is constant".format(feature_column.name))
+        return pd.Series({"type": "const", "rejected": False}, name=feature_column.name)
 
     else:
         if target_is_binary:
             # Decide if the current feature is binary or not
-            if len(set(X[feature].values)) == 2:
+            if len(set(feature_column.values)) == 2:
                 type = "binary"
-                p_value = target_binary_feature_binary_test(X[feature], y, settings)
+                p_value = target_binary_feature_binary_test(feature_column, y, settings)
             else:
                 type = "real"
-                p_value = target_binary_feature_real_test(X[feature], y, settings)
+                p_value = target_binary_feature_real_test(feature_column, y, settings)
         else:
             # Decide if the current feature is binary or not
-            if len(set(X[feature].values)) == 2:
+            if len(set(feature_column.values)) == 2:
                 type = "binary"
-                p_value = target_real_feature_binary_test(X[feature], y, settings)
+                p_value = target_real_feature_binary_test(feature_column, y, settings)
             else:
                 type = "real"
-                p_value = target_real_feature_real_test(X[feature], y, settings)
+                p_value = target_real_feature_real_test(feature_column, y, settings)
 
-        return pd.Series({"p_value": p_value, "type": type}, name=feature)
+        return pd.Series({"p_value": p_value, "type": type}, name=feature_column.name)
 
 
 def benjamini_hochberg_test(df_pvalues, settings):

--- a/tsfresh/feature_selection/settings.py
+++ b/tsfresh/feature_selection/settings.py
@@ -56,3 +56,6 @@ class FeatureSignificanceTestsSettings(object):
 
         #: Number of processes to use during the p-value calculation
         self.n_processes = int(os.getenv("NUMBER_OF_CPUS") or cpu_count())
+
+        # Size of the chunks submitted to the worker processes
+        self.chunksize = None


### PR DESCRIPTION
The PR is not ready for a merge. I opened it to facilitate the discussion of the introduced changes. Please comment!

Here's what I did: I extracted the parallel calculation of the features and added two functions for this purpose. One works just as before, parallelising the calculation per time series kind. The other additionally parallelizes per sample.
As the parallelization per sample introduces significant overhead on large data sets with several time series per sample, we should offer both options. Therefore I introduced a new optional argument to the extract_features function. A rule-of-thumb is used to determine the default strategy.

TODO:
- ~~Ensure test coverage for both parallel extract functions~~
- ~~Add documentation discussing the tradeoffs involved in the two options~~
- ~~Add test cases asserting the resulting feature matrix on given input is identical for both options~~
- Optional: Add test case to validate rule-of-thumb
- ~~solve merge conflict~~