### PR TITLE
always use value column name as feature name

### DIFF
--- a/tests/utilities/test_dataframe_functions.py
+++ b/tests/utilities/test_dataframe_functions.py
@@ -102,10 +102,10 @@ class NormalizeTestCase(TestCase):
 
         self.assertEqual(column_id, "id")
         self.assertEqual(column_value, "value")
-        self.assertIn("feature", result_dict)
-        six.assertCountEqual(self, list(result_dict["feature"].columns), ["id", "value"])
-        self.assertEqual(list(result_dict["feature"]["value"]), [3])
-        self.assertEqual(list(result_dict["feature"]["id"]), [0])
+        self.assertIn("value", result_dict)
+        six.assertCountEqual(self, list(result_dict["value"].columns), ["id", "value"])
+        self.assertEqual(list(result_dict["value"]["value"]), [3])
+        self.assertEqual(list(result_dict["value"]["id"]), [0])
 
         # Let the function find the values
         test_df = pd.DataFrame([{"id": 0, "a": 3, "b": 5, "sort": 1}])

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -234,7 +234,7 @@ def normalize_input_to_internal_representation(df_or_dict, column_id, column_sor
             kind_to_df_map = {key: group.copy().drop(column_kind, axis=1) for key, group in df_or_dict.groupby(column_kind)}
         else:
             if column_value is not None:
-                kind_to_df_map = {"feature": df_or_dict.copy()}
+                kind_to_df_map = {column_value: df_or_dict.copy()}
             else:
                 id_and_sort_column = [_f for _f in [column_id, column_sort] if _f is not None]
                 kind_to_df_map = {key: df_or_dict[[key] + id_and_sort_column].copy().rename(columns={key: "_value"})


### PR DESCRIPTION
at the moment if one does 

```
 X_ts = extract_features(ts, column_id='id', column_value="value", feature_extraction_settings=extraction_settings)
```

one gets features named `feature__mean` instead of `value__mean`. this does not follow our own naming convention.