### PR TITLE
Tried to reduce the number of temporary copies 

### DIFF
--- a/tests/feature_extraction/test_extraction.py
+++ b/tests/feature_extraction/test_extraction.py
@@ -11,6 +11,7 @@ from tsfresh.feature_extraction.settings import FeatureExtractionSettings
 import six
 import os
 
+
 class ExtractionTestCase(DataTestCase):
     """The unit tests in this module make sure if the time series features are created properly"""
 
@@ -72,9 +73,11 @@ class ExtractionTestCase(DataTestCase):
     def test_extract_features_for_one_time_series(self):
         # todo: implement more methods and test more aspects
         df = self.create_test_data_sample()
-        extracted_features = _extract_features_for_one_time_series(["b", df.loc[df.kind == "b", ["val", "id"]]],
-                                                                   settings=self.settings,
-                                                                   column_value="val", column_id="id")
+        kind, extracted_features = _extract_features_for_one_time_series(["b", df.loc[df.kind == "b", ["val", "id"]]],
+                                                                         settings=self.settings,
+                                                                         column_value="val", column_id="id")
+
+        self.assertEqual(kind, "b")
 
         self.assertIsInstance(extracted_features, pd.DataFrame)
         self.assertTrue(np.all(extracted_features.b__sum_values == np.array([757, 695])))
@@ -84,10 +87,11 @@ class ExtractionTestCase(DataTestCase):
         self.assertTrue(np.all(extracted_features.b__median == np.array([39.5, 28.0])))
 
         df_sts = self.create_one_valued_time_series()
-        extracted_features_sts = _extract_features_for_one_time_series(["a", df_sts[["val", "id"]]],
+        kind, extracted_features_sts = _extract_features_for_one_time_series(["a", df_sts[["val", "id"]]],
                                                                        settings=self.settings,
                                                                        column_value="val", column_id="id")
 
+        self.assertEqual(kind, "a")
         self.assertIsInstance(extracted_features_sts, pd.DataFrame)
         self.assertTrue(np.all(extracted_features_sts.a__maximum == np.array([1.0, 6.0])))
         self.assertTrue(np.all(extracted_features_sts.a__sum_values == np.array([1.0, 11.0])))
@@ -164,7 +168,7 @@ class ExtractionTestCase(DataTestCase):
         features_per_sample = extract_features(df, self.settings, "id", "sort", "kind", "val",
                                                parallelization='per_sample')
         features_per_kind = extract_features(df, self.settings, "id", "sort", "kind", "val",
-                                               parallelization='per_kind')
+                                             parallelization='per_kind')
 
         six.assertCountEqual(self, features_per_sample.columns, features_per_kind.columns)
 

--- a/tests/feature_extraction/test_settings.py
+++ b/tests/feature_extraction/test_settings.py
@@ -98,7 +98,7 @@ class TestMinimalSettingsObject(TestCase):
 
         mfs = MinimalFeatureExtractionSettings()
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
-        extracted_features = _extract_features_for_one_time_series([0, data], settings=mfs,
+        kind, extracted_features = _extract_features_for_one_time_series([0, data], settings=mfs,
                                                                    column_value="value", column_id="id")
         six.assertCountEqual(self, extracted_features.columns,
                              ["0__median", "0__standard_deviation", "0__sum_values", "0__maximum", "0__variance",

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -19,6 +19,7 @@ import numpy as np
 from tsfresh.utilities import dataframe_functions, profiling
 from tsfresh.feature_extraction.settings import FeatureExtractionSettings
 
+from itertools import groupby
 
 _logger = logging.getLogger(__name__)
 
@@ -157,7 +158,7 @@ def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, col
     pool.close()
 
     # Concatenate all partial results
-    result = pd.concat(extracted_features, axis=1, join='outer').astype(np.float64)
+    result = pd.concat((df for _, df in extracted_features), axis=1, join='outer').astype(np.float64)
 
     pool.join()
     return result
@@ -185,36 +186,39 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
     :return: The (maybe imputed) DataFrame containing extracted features.
     :rtype: pandas.DataFrame
     """
+
     partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
                                                            column_id=column_id,
                                                            column_value=column_value,
                                                            settings=settings)
     pool = Pool(settings.n_processes)
 
-    # Submit map jobs per kind per sample
-    results_fifo = Queue()
-    for kind, df_kind in kind_to_df_map.items():
-        df_grouped_by_id = df_kind.groupby(column_id)
-        results_fifo.put(
-            pool.map_async(
-                partial_extract_features_for_one_time_series,
-                [(kind, df_group) for _, df_group in df_grouped_by_id],
-                chunksize=settings.chunksize
-            )
-        )
+    # Submit map jobs per kind per sample in a generator object
+    kind_and_df_group_list = ((kind, df_group)
+                              for kind, df_kind in kind_to_df_map.items()
+                              for _, df_group in df_kind.groupby(column_id))
 
+    dfs_per_kind = pool.map(
+        partial_extract_features_for_one_time_series,
+        kind_and_df_group_list,
+        chunksize=settings.chunksize,
+    )
+
+    # Wait for the pool to finish its job
     pool.close()
+    pool.join()
 
-    # Wait for the jobs to complete and concatenate the partial results
-    dfs_per_kind = []
-    while not results_fifo.empty():
-        map_result = results_fifo.get()
-        dfs = map_result.get()
-        dfs_per_kind.append(pd.concat(dfs, axis=0).astype(np.float64))
+    # dfs_per_kind is now a list of (kind, df). We want to extract all dfs with the same kind and concatenate them
+    # We have to make sure to not create unnecessary copies here.
+
+    # We will use groupby to group the list by their kind entry. The keyfunction extracts this kind for us.
+    keyfunction = lambda (kind, df): kind
+    dfs_per_kind = sorted(dfs_per_kind, key=keyfunction)
+    dfs_per_kind = (pd.concat((df for kind, df in dfs), axis=0).astype(np.float64)
+                    for kind, dfs in groupby(dfs_per_kind, keyfunction))
 
     result = pd.concat(dfs_per_kind, axis=1).astype(np.float64)
 
-    pool.join()
     return result
 
 
@@ -315,4 +319,4 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
                 extracted_features = pd.concat(list_of_extracted_feature_dataframes, axis=1,
                                                join_axes=[extracted_features.index])
 
-        return extracted_features
+        return column_prefix, extracted_features

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -212,7 +212,7 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
     # We have to make sure to not create unnecessary copies here.
 
     # We will use groupby to group the list by their kind entry. The keyfunction extracts this kind for us.
-    keyfunction = lambda (kind, df): kind
+    keyfunction = lambda kind_and_df: kind_and_df[0]
     dfs_per_kind = sorted(dfs_per_kind, key=keyfunction)
     dfs_per_kind = (pd.concat((df for kind, df in dfs), axis=0).astype(np.float64)
                     for kind, dfs in groupby(dfs_per_kind, keyfunction))


### PR DESCRIPTION
by using generator objects wherever possible.

This may solve #107 
@MaxBenChrist can you check with your sample?

For this I had to change the _extract function to return the kind and the dataframe.