### PR TITLE
Improve performance of the impute function.

### DIFF
--- a/tests/utilities/test_dataframe_functions.py
+++ b/tests/utilities/test_dataframe_functions.py
@@ -9,8 +9,8 @@ from tsfresh.utilities import dataframe_functions
 import numpy as np
 import six
 
-class NormalizeTestCase(TestCase):
 
+class NormalizeTestCase(TestCase):
     def test_with_dictionaries_one_row(self):
         test_df = pd.DataFrame([{"value": 1, "id": "id_1"}])
         test_dict = {"a": test_df, "b": test_df}
@@ -32,7 +32,7 @@ class NormalizeTestCase(TestCase):
         self.assertEqual(result_dict["a"].iloc[0].to_dict(), {"value": 1, "id": "id_1"})
 
         # The algo should choose the correct value column
-        result_dict, column_id, column_value =\
+        result_dict, column_id, column_value = \
             dataframe_functions.normalize_input_to_internal_representation(test_dict, "id", None, None, None)
         self.assertEqual(column_value, "value")
         self.assertEqual(column_id, "id")
@@ -82,7 +82,6 @@ class NormalizeTestCase(TestCase):
         self.assertEqual(column_id, "id")
 
     def test_with_df(self):
-
         # give everyting
         test_df = pd.DataFrame([{"id": 0, "kind": "a", "value": 3, "sort": 1}])
         result_dict, column_id, column_value = \
@@ -176,9 +175,11 @@ class CheckForNanTestCase(TestCase):
         self.assertRaises(ValueError, dataframe_functions.check_for_nans_in_columns, test_df)
         self.assertRaises(ValueError, dataframe_functions.check_for_nans_in_columns, test_df, ["a", "b"])
         self.assertRaises(ValueError, dataframe_functions.check_for_nans_in_columns, test_df, ["b"])
+        self.assertRaises(ValueError, dataframe_functions.check_for_nans_in_columns, test_df, "b")
         self.assertRaises(ValueError, dataframe_functions.check_for_nans_in_columns, test_df, ["c", "b"])
 
         dataframe_functions.check_for_nans_in_columns(test_df, columns=["a", "c"])
+        dataframe_functions.check_for_nans_in_columns(test_df, columns="a")
 
 
 class ImputeTestCase(TestCase):

--- a/tests/utilities/test_dataframe_functions.py
+++ b/tests/utilities/test_dataframe_functions.py
@@ -228,12 +228,11 @@ class ImputeTestCase(TestCase):
         self.assertEqual(list(df.value_c), [1, -3, -3, 3])
 
     def test_impute_range(self):
-
         def get_df():
             return pd.DataFrame(np.transpose([[0, 1, 2, np.NaN],
-                                            [1, np.PINF, 2, 3],
-                                            [1, -3, np.NINF, 3]]),
-                              columns=["value_a", "value_b", "value_c"])
+                                              [1, np.PINF, 2, 3],
+                                              [1, -3, np.NINF, 3]]),
+                                columns=["value_a", "value_b", "value_c"])
 
         # check if values are replaced correctly
         df = get_df()
@@ -261,12 +260,11 @@ class ImputeTestCase(TestCase):
         self.assertRaises(ValueError, dataframe_functions.impute_dataframe_range,
                           df, col_to_max, col_to_min, col_to_median)
 
-        # check for error if column key is too much
+        # check for no error if column key is too much
         col_to_max = {"value_a": 200, "value_b": 200, "value_c": 200}
         col_to_min = {"value_a": -134, "value_b": -134, "value_c": -134}
         col_to_median = {"value_a": 55, "value_b": 55, "value_c": 55, "value_d": 55}
-        self.assertRaises(ValueError, dataframe_functions.impute_dataframe_range,
-                          df, col_to_max, col_to_min, col_to_median)
+        dataframe_functions.impute_dataframe_range(df, col_to_max, col_to_min, col_to_median)
 
         # check for error if replacement value is not finite
         df = get_df()
@@ -288,7 +286,6 @@ class ImputeTestCase(TestCase):
         col_to_median = {"value_a": 55, "value_b": 55, "value_c": np.PINF}
         self.assertRaises(ValueError, dataframe_functions.impute_dataframe_range,
                           df, col_to_max, col_to_min, col_to_median)
-
 
 
 class RestrictTestCase(TestCase):

--- a/tests/utilities/test_dataframe_functions.py
+++ b/tests/utilities/test_dataframe_functions.py
@@ -227,14 +227,6 @@ class ImputeTestCase(TestCase):
         self.assertEqual(list(df.value_b), [1, 200, 2, 3])
         self.assertEqual(list(df.value_c), [1, -3, -134, 3])
 
-        # now check interplay with get_range_values_per_column
-        df = get_df()
-        col_to_max, col_to_min, col_to_median = dataframe_functions.get_range_values_per_column(df)
-        dataframe_functions.impute_dataframe_range(df, col_to_max, col_to_min, col_to_median)
-        self.assertEqual(list(df.value_a), [0, 1, 2, 1])
-        self.assertEqual(list(df.value_b), [1, 3, 2, 3])
-        self.assertEqual(list(df.value_c), [1, -3, -3, 3])
-
         # check for error if column key is missing
         df = get_df()
         col_to_max = {"value_a": 200, "value_b": 200, "value_c": 200}

--- a/tsfresh/transformers/relevant_feature_augmenter.py
+++ b/tsfresh/transformers/relevant_feature_augmenter.py
@@ -8,7 +8,7 @@ from functools import partial
 from tsfresh.feature_extraction.settings import FeatureExtractionSettings
 from tsfresh.transformers.feature_augmenter import FeatureAugmenter
 from tsfresh.transformers.feature_selector import FeatureSelector
-from tsfresh.utilities.dataframe_functions import impute_dataframe_range, get_range_values_per_column
+from tsfresh.utilities.dataframe_functions import impute, get_range_values_per_column, impute_dataframe_range
 
 
 # TODO: Add more testcases
@@ -88,6 +88,7 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
     :class:`~tsfresh.feature_selection.settings.FeatureSignificanceTestsSettings`. However, the default settings which
     are used if you pass no objects are often quite sensible.
     """
+
     def __init__(self,
                  evaluate_only_added_features=True,
                  feature_selection_settings=None,
@@ -121,17 +122,14 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         # We require to have IMPUTE!
         if feature_extraction_settings is None:
             feature_extraction_settings = FeatureExtractionSettings()
-
-        # Range will be our default imputation strategy
-        feature_extraction_settings.IMPUTE = impute_dataframe_range
+            # Range will be our default imputation strategy
+            feature_extraction_settings.IMPUTE = impute
 
         self.feature_extractor = FeatureAugmenter(feature_extraction_settings,
                                                   column_id, column_sort, column_kind, column_value)
-
         self.feature_selector = FeatureSelector(feature_selection_settings)
 
         self.evaluate_only_added_features = evaluate_only_added_features
-
         self.timeseries_container = timeseries_container
 
     def set_timeseries_container(self, timeseries_container):
@@ -181,11 +179,12 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
             X_tmp = pd.DataFrame(index=X.index)
         else:
             X_tmp = X
-
         X_augmented = self.feature_extractor.transform(X_tmp)
 
-        if self.feature_extractor.settings.IMPUTE is impute_dataframe_range:
-            self.col_to_max, self.col_to_min, self.col_to_median = get_range_values_per_column(X_augmented)
+        if self.feature_extractor.settings.IMPUTE is impute:
+            col_to_max, col_to_min, col_to_median = get_range_values_per_column(X_augmented)
+            self.feature_extractor.settings.IMPUTE = partial(impute_dataframe_range, col_to_max=col_to_max,
+                                                             col_to_min=col_to_min, col_to_median=col_to_median)
 
         self.feature_selector.fit(X_augmented, y)
 
@@ -217,14 +216,7 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
 
         relevant_extraction_settings = FeatureExtractionSettings.from_columns(relevant_time_series_features)
         relevant_extraction_settings.set_default = False
-
-        # Set imputing strategy
-        if self.feature_extractor.settings.IMPUTE is impute_dataframe_range:
-            relevant_extraction_settings.IMPUTE = partial(impute_dataframe_range, col_to_max=self.col_to_max,
-                                                          col_to_min=self.col_to_min, col_to_median=self.col_to_median)
-        else:
-            relevant_extraction_settings.IMPUTE = self.feature_extractor.settings.IMPUTE
-
+        relevant_extraction_settings.IMPUTE = self.feature_extractor.settings.IMPUTE
         relevant_feature_extractor = FeatureAugmenter(settings=relevant_extraction_settings,
                                                       column_id=self.feature_extractor.column_id,
                                                       column_sort=self.feature_extractor.column_sort,

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -30,9 +30,11 @@ def check_for_nans_in_columns(df, columns=None):
     if columns is None:
         columns = df.columns
 
-    for key in columns:
-        if df[key].isnull().any():
-            raise ValueError("Column {} of dataframe must not contain NaN values".format(key))
+    if pd.isnull(df.loc[:, columns]).any().any():
+        if not isinstance(columns, list):
+            columns = list(columns)
+        raise ValueError("Columns {} of dataframe must not contain NaN values".format(
+            df.loc[:, columns].columns[pd.isnull(df.loc[:, columns]).sum() > 0].tolist()))
 
 
 def impute(df_impute):

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -33,7 +33,7 @@ def check_for_nans_in_columns(df, columns=None):
     if pd.isnull(df.loc[:, columns]).any().any():
         if not isinstance(columns, list):
             columns = list(columns)
-        raise ValueError("Columns {} of dataframe must not contain NaN values".format(
+        raise ValueError("Columns {} of DataFrame must not contain NaN values".format(
             df.loc[:, columns].columns[pd.isnull(df.loc[:, columns]).sum() > 0].tolist()))
 
 

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -78,7 +78,7 @@ def impute(df_impute):
         df_impute.values[ indices ] = newValues
 
     # Ensure a type of "np.float64"
-    df_impute.astype(np.float64)
+    df_impute.astype(np.float64,copy=False)
 
 
 def impute_dataframe_zero(df_impute):

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -86,9 +86,8 @@ def impute(df_impute):
 
 def impute_dataframe_zero(df_impute):
     """
-    Replaces all ``NaNs`` and ``infs`` from the DataFrame `df_impute` with 0s.
-
-    `df_impute` will be modified in place. All its columns will be of datatype ``np.float64``.
+    Replaces all ``NaNs``, ``-infs`` and ``+infs`` from the DataFrame `df_impute` with 0s.
+    The `df_impute` will be modified in place. All its columns will be into converted into dtype ``np.float64``.
 
     :param df_impute: DataFrame to impute
     :type df_impute: pandas.DataFrame

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -10,7 +10,6 @@ import numpy as np
 import pandas as pd
 import logging
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -53,8 +52,9 @@ def impute(df_impute):
 
     :param df_impute: DataFrame to impute
     :type df_impute: pandas.DataFrame
-    :return: df_impute: imputed DataFrame
-    :rtype: df_impute: pandas.DataFrame
+
+    :return df_impute: imputed DataFrame
+    :rtype df_impute: pandas.DataFrame
     """
     col_to_max, col_to_min, col_to_median = get_range_values_per_column(df_impute)
 
@@ -91,8 +91,9 @@ def impute_dataframe_zero(df_impute):
 
     :param df_impute: DataFrame to impute
     :type df_impute: pandas.DataFrame
-    :return: df_impute: imputed DataFrame
-    :rtype: df_impute: pandas.DataFrame
+
+    :return df_impute: imputed DataFrame
+    :rtype df_impute: pandas.DataFrame
     """
 
     df_impute.replace([np.PINF, np.NINF], 0, inplace=True)
@@ -126,6 +127,9 @@ def impute_dataframe_range(df_impute, col_to_max=None, col_to_min=None, col_to_m
     :type col_to_max: dict
     :param col_to_median: Dictionary mapping column names to median values
     :type col_to_max: dict
+
+    :return df_impute: imputed DataFrame
+    :rtype df_impute: pandas.DataFrame
     """
 
     if col_to_median is None:
@@ -164,17 +168,21 @@ def impute_dataframe_range(df_impute, col_to_max=None, col_to_min=None, col_to_m
 
     return df_impute
 
+
 def get_range_values_per_column(df):
     """
     Retrieves the finite max, min and mean values per column in `df` and stores them in three dictionaries, each mapping
     from column name to value. If a column does not contain finite value, 0 is stored instead.
 
-    :param df: ``Dataframe``
+    :param df: the Dataframe to get columnswise max, min and median from
+    :type df: pandas.DataFrame
+
     :return: Dictionaries mapping column names to max, min, mean values
+    :rtype: (dict, dict, dict)
     """
     column = df.get_values()
     masked = np.ma.masked_invalid(column)
-    
+
     columns = df.columns
 
         
@@ -200,8 +208,9 @@ def restrict_input_to_index(df_or_dict, column_id, index):
     :type column_id: basestring
     :param index: Index containing the ids
     :type index: Iterable or pandas.Series
-    :return: the restricted df_or_dict
-    :rtype: dict or pandas.DataFrame
+
+    :return df_or_dict_restricted: the restricted df_or_dict
+    :rtype df_or_dict_restricted: dict or pandas.DataFrame
     :raise: ``TypeError`` if df_or_dict is not of type dict or pandas.DataFrame
     """
     if isinstance(df_or_dict, pd.DataFrame):
@@ -248,6 +257,7 @@ def normalize_input_to_internal_representation(df_or_dict, column_id, column_sor
         DataFrames in the dictionaries). If it is None, it is assumed that there is only a single remaining column
         in the DataFrame(s) (otherwise an exception is raised).
     :type column_value: basestring or None
+
     :return: A tuple of 3 elements: the normalized DataFrame as a dictionary mapping from the kind (as a string) to the
              corresponding DataFrame, the name of the id column and the name of the value column
     :rtype: (dict, basestring, basestring)

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -171,8 +171,11 @@ def impute_dataframe_range(df_impute, col_to_max=None, col_to_min=None, col_to_m
 
 def get_range_values_per_column(df):
     """
-    Retrieves the finite max, min and mean values per column in `df` and stores them in three dictionaries, each mapping
-    from column name to value. If a column does not contain finite value, 0 is stored instead.
+    Retrieves the finite max, min and mean values per column in the DataFrame `df` and stores them in three
+    dictionaries. Those dictionaries `col_to_max`, `col_to_min`, `col_to_median` map the columnname to the maximal,
+    minimal or median value of that column.
+
+    If a column does not contain any finite values at all, a 0 is stored instead.
 
     :param df: the Dataframe to get columnswise max, min and median from
     :type df: pandas.DataFrame

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -92,10 +92,16 @@ def impute_dataframe_zero(df_impute):
 
     :param df_impute: DataFrame to impute
     :type df_impute: pandas.DataFrame
+    :return: df_impute: imputed DataFrame
+    :rtype: df_impute: pandas.DataFrame
     """
 
     df_impute.replace([np.PINF, np.NINF], 0, inplace=True)
     df_impute.fillna(0, inplace=True)
+
+    # Ensure a type of "np.float64"
+    df_impute.astype(np.float64, copy=False)
+    return df_impute
 
 
 def impute_dataframe_range(df_impute, col_to_max=None, col_to_min=None, col_to_median=None):

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -96,6 +96,7 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
         * ``NaN`` -> by value in col_to_median
 
     If a column of df_impute is not found in the one of the dictionaries, this method will raise a ValueError.
+    Also, if one of the values to replace is not finite a ValueError is returned
 
     This function modifies `df_impute` in place. Unless the dictionaries contain ``NaNs`` or ``infs``, df_impute is
     guaranteed to not contain any non-finite values.
@@ -112,7 +113,8 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
 
     :return df_impute: imputed DataFrame
     :rtype df_impute: pandas.DataFrame
-    :raise ValueError: if a column of df_impute is missing in col_to_max, col_to_min or col_to_median
+    :raise ValueError: if a column of df_impute is missing in col_to_max, col_to_min or col_to_median or a value
+                       to replace is non finite
     """
     columns = df_impute.columns
 
@@ -122,6 +124,13 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
                     set(col_to_min.keys()) != set(columns):
         ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains more or less keys "
                    "than the column names in df")
+
+    # check if there are non finite values for the replacement
+    if np.any(~np.isfinite(col_to_median.values())) or \
+        np.any(~np.isfinite(col_to_min.values())) or \
+        np.any(~np.isfinite(col_to_max.values())):
+        ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains non finite values to to "
+                   "replace")
 
     # Replacing values
     # +inf -> max

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -119,16 +119,16 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
     columns = df_impute.columns
 
     # Making sure col_to_median, col_to_max and col_to_min have entries for every column
-    if set(col_to_median.keys()) != set(columns) or \
-                    set(col_to_max.keys()) != set(columns) or \
-                    set(col_to_min.keys()) != set(columns):
+    if not set(columns) <= set(col_to_median.keys()) or \
+            not set(columns) <= set(col_to_max.keys()) or \
+            not set(columns) <= set(col_to_min.keys()):
         raise ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains more or less keys "
-                   "than the column names in df")
+                         "than the column names in df")
 
     # check if there are non finite values for the replacement
     if np.any(~np.isfinite(col_to_median.values())) or \
-        np.any(~np.isfinite(col_to_min.values())) or \
-        np.any(~np.isfinite(col_to_max.values())):
+            np.any(~np.isfinite(col_to_min.values())) or \
+            np.any(~np.isfinite(col_to_max.values())):
         raise ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains non finite values "
                          "to to replace")
 

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -118,8 +118,8 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
 
     # Making sure col_to_median, col_to_max and col_to_min have entries for every column
     if set(col_to_median.keys()) != set(columns) or \
-       set(col_to_max.keys()) != set(columns) or \
-       set(col_to_min.keys()) != set(columns):
+                    set(col_to_max.keys()) != set(columns) or \
+                    set(col_to_min.keys()) != set(columns):
         ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains more or less keys "
                    "than the column names in df")
 
@@ -167,13 +167,12 @@ def get_range_values_per_column(df):
     is_col_non_finite = masked.mask.sum(axis=0) == masked.data.shape[0]
 
     if np.any(is_col_non_finite):
-
         # We have columns that does not contain any finite value at all, so we will store 0 instead.
         _logger.warning("The columns {} did not have any finite values. Filling with zeros.".format(
             df.iloc[:, np.where(is_col_non_finite)[0]].columns.values))
 
-        masked.data[:, is_col_non_finite] = 0         # Set the values of the columns to 0
-        masked.mask[:, is_col_non_finite] = False     # Remove the mask for this column
+        masked.data[:, is_col_non_finite] = 0  # Set the values of the columns to 0
+        masked.mask[:, is_col_non_finite] = False  # Remove the mask for this column
 
     # fetch max, min and median for all columns
     col_to_max = dict(zip(columns, np.max(masked, axis=0)))
@@ -203,7 +202,7 @@ def restrict_input_to_index(df_or_dict, column_id, index):
         df_or_dict_restricted = df_or_dict[df_or_dict[column_id].isin(index)]
     elif isinstance(df_or_dict, dict):
         df_or_dict_restricted = {kind: df[df[column_id].isin(index)]
-                                  for kind, df in df_or_dict.items()}
+                                 for kind, df in df_or_dict.items()}
     else:
         raise TypeError("df_or_dict should be of type dict or pandas.DataFrame")
 
@@ -256,7 +255,8 @@ def normalize_input_to_internal_representation(df_or_dict, column_id, column_sor
         kind_to_df_map = {key: df.copy() for key, df in df_or_dict.items()}
     else:
         if column_kind is not None:
-            kind_to_df_map = {key: group.copy().drop(column_kind, axis=1) for key, group in df_or_dict.groupby(column_kind)}
+            kind_to_df_map = {key: group.copy().drop(column_kind, axis=1) for key, group in
+                              df_or_dict.groupby(column_kind)}
         else:
             if column_value is not None:
                 kind_to_df_map = {column_value: df_or_dict.copy()}
@@ -265,7 +265,7 @@ def normalize_input_to_internal_representation(df_or_dict, column_id, column_sor
                 kind_to_df_map = {key: df_or_dict[[key] + id_and_sort_column].copy().rename(columns={key: "_value"})
                                   for key in df_or_dict.columns if key not in id_and_sort_column}
 
-                #todo: is this the right check?
+                # todo: is this the right check?
                 if len(kind_to_df_map) < 1:
                     raise ValueError("You passed in a dataframe without a value column.")
                 column_value = "_value"
@@ -305,11 +305,12 @@ def normalize_input_to_internal_representation(df_or_dict, column_id, column_sor
 
         for kind in kind_to_df_map:
             if not column_value in kind_to_df_map[kind].columns:
-                raise ValueError("You did not pass a column_value and there is not a single candidate in all data frames.")
+                raise ValueError(
+                    "You did not pass a column_value and there is not a single candidate in all data frames.")
 
     # Require no NaNs in value columns
     for kind in kind_to_df_map:
         if kind_to_df_map[kind][column_value].isnull().any():
-                raise ValueError("You have NaN values in your value column.")
+            raise ValueError("You have NaN values in your value column.")
 
     return kind_to_df_map, column_id, column_value

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -127,9 +127,9 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
                          "than the column names in df")
 
     # check if there are non finite values for the replacement
-    if np.any(~np.isfinite(col_to_median.values())) or \
-            np.any(~np.isfinite(col_to_min.values())) or \
-            np.any(~np.isfinite(col_to_max.values())):
+    if np.any(~np.isfinite([col_to_median.values()])) or \
+            np.any(~np.isfinite([col_to_min.values()])) or \
+            np.any(~np.isfinite([col_to_max.values()])):
         raise ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains non finite values "
                          "to to replace")
 

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -127,9 +127,9 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
                          "than the column names in df")
 
     # check if there are non finite values for the replacement
-    if np.any(~np.isfinite([col_to_median.values()])) or \
-            np.any(~np.isfinite([col_to_min.values()])) or \
-            np.any(~np.isfinite([col_to_max.values()])):
+    if np.any(~np.isfinite(list(col_to_median.values()))) or \
+            np.any(~np.isfinite(list(col_to_min.values()))) or \
+            np.any(~np.isfinite(list(col_to_max.values()))):
         raise ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains non finite values "
                          "to to replace")
 

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -122,15 +122,15 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
     if set(col_to_median.keys()) != set(columns) or \
                     set(col_to_max.keys()) != set(columns) or \
                     set(col_to_min.keys()) != set(columns):
-        ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains more or less keys "
+        raise ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains more or less keys "
                    "than the column names in df")
 
     # check if there are non finite values for the replacement
     if np.any(~np.isfinite(col_to_median.values())) or \
         np.any(~np.isfinite(col_to_min.values())) or \
         np.any(~np.isfinite(col_to_max.values())):
-        ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains non finite values to to "
-                   "replace")
+        raise ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains non finite values "
+                         "to to replace")
 
     # Replacing values
     # +inf -> max

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -131,7 +131,7 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
             np.any(~np.isfinite(list(col_to_min.values()))) or \
             np.any(~np.isfinite(list(col_to_max.values()))):
         raise ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains non finite values "
-                         "to to replace")
+                         "to replace")
 
     # Replacing values
     # +inf -> max

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -48,13 +48,13 @@ def impute(df_impute):
 
     If the column does not contain finite values at all, it is filled with zeros.
 
-    This function modifies `df_impute` in place. After that, df_impute is
-    guaranteed to not contain any non-finite values. Also, all columns will be guaranteed to be of type ``np.float64``.
+    This function modifies `df_impute` in place. After that, df_impute is guaranteed to not contain any non-finite
+    values. Also, all columns will be guaranteed to be of type ``np.float64``.
 
     :param df_impute: DataFrame to impute
     :type df_impute: pandas.DataFrame
-    :return: None
-    :rtype: None
+    :return: df_impute: imputed DataFrame
+    :rtype: df_impute: pandas.DataFrame
     """
     col_to_max, col_to_min, col_to_median = get_range_values_per_column(df_impute)
 
@@ -80,7 +80,8 @@ def impute(df_impute):
         df_impute.values[ indices ] = newValues
 
     # Ensure a type of "np.float64"
-    df_impute.astype(np.float64,copy=False)
+    df_impute.astype(np.float64, copy=False)
+    return df_impute
 
 
 def impute_dataframe_zero(df_impute):

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -98,8 +98,7 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
     If a column of df_impute is not found in the one of the dictionaries, this method will raise a ValueError.
     Also, if one of the values to replace is not finite a ValueError is returned
 
-
-    This function modifies `df_impute` in place. Unless the dictionaries contain ``NaNs`` or ``infs``, df_impute is
+    This function modifies `df_impute` in place. Afterwards df_impute is
     guaranteed to not contain any non-finite values.
     Also, all columns will be guaranteed to be of type ``np.float64``.
 


### PR DESCRIPTION
Improve performance of the functions:
- utilities.dataframe_function.get_range_values_per_column(df)
- utilities.dataframe_function.impute(df_impute)
More specifically: apply the impute function directly on numpy array to improve computation time.

Now the impute function runs in 109ms (60 samples, 14256 features (or columns) ).

Note: I did not impoved the performance of impute_dataframe_range(...) since it would have been to much of a hassle to implement all the checks in that function, e.g. in case the min/max/median values of each columns are not present. In our case we call the get_range_values_per_column just before so these checks are not necessary.
So I just reimplemented the function impute_dataframe_rage directly in the impute function. This is less modular. Maybe you could pack this code in a new impute_dataframe_range function.

Solve the issue #123 .