### PR TITLE
renaming of settings classes and arguments for extract_features

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ The following chapters will explain the tsfresh package in detail:
    Data Formats <text/data_formats>
    scikit-learn Transformers <text/sklearn_transformers>
    Feature Calculation <text/feature_calculation>
-   Feature Extraction Settings <text/feature_extraction_settings>
+   Feature Calculator Settings <text/feature_extraction_settings>
    Feature Filtering <text/feature_filtering>
    How to write custom Feature Calculators <text/how_to_add_custom_feature>
    Parallelization <text/parallelization>

--- a/docs/text/feature_extraction_settings.rst
+++ b/docs/text/feature_extraction_settings.rst
@@ -12,8 +12,38 @@ After digging deeper into your data, you maybe want to calculate more of a certa
 type. So, you need to use custom settings for the feature extractors. To do that with tsfresh you will have to use a
 custom settings object, like shown now:
 
->>> from tsfresh.feature_extraction import FeatureExtractionSettings
->>> settings = FeatureExtractionSettings()
+>>> from tsfresh.feature_extraction import ComprehensiveFCParameters
+>>> settings = ExtendedFCParameters()
+>>> # Set here the options of the settings object as shown in the chapters below
+>>> # ...
+>>> from tsfresh.feature_extraction import extract_features
+>>> extract_features(df, default_para_map=settings)
+
+
+The
+feature calculators in this package).
+
+After digging deeper into your data, you maybe want to calculate more of a certain type of feature and less of another
+type. So, you need to use custom settings for the feature extractors. To do that with tsfresh you will have to use a
+custom settings object, like shown now:
+
+>>> from tsfresh.feature_extraction import ComprehensiveFCParameters
+>>> settings = ExtendedFCParameters()
+>>> # Set here the options of the settings object as shown in the chapters below
+>>> # ...
+>>> from tsfresh.feature_extraction import extract_features
+>>> extract_features(df, default_para_map=settings)
+
+
+The
+feature calculators in this package).
+
+After digging deeper into your data, you maybe want to calculate more of a certain type of feature and less of another
+type. So, you need to use custom settings for the feature extractors. To do that with tsfresh you will have to use a
+custom settings object, like shown now:
+
+>>> from tsfresh.feature_extraction import ExtendedFCParameters
+>>> settings = ComprehensiveFCParameters()
 >>> # Set here the options of the settings object as shown in the chapters below
 >>> # ...
 >>> from tsfresh.feature_extraction import extract_features
@@ -43,13 +73,13 @@ So you can control, which features will be extracted, by adding/removing either 
 
 For convenience, there are already three dict predefined, which can be used right away:
 
-* :class:`tsfresh.feature_extraction.settings.FeatureExtractionSettings`: includes all features without parameters and
+* :class:`tsfresh.feature_extraction.settings.ComprehensiveFCParameters`: includes all features without parameters and
   all features will parameters, with quite some different parameter combinations. This is the default of you do not
   hand in a `default_para_map` at all.
-* :class:`tsfresh.feature_extraction.settings.MinimalFeatureExtractionSettings`: includes only few features
+* :class:`tsfresh.feature_extraction.settings.MinimalFCParameters`: includes only few features
   and can be used for quick tests. The features which have the "minimal" attribute are used here.
-* :class:`tsfresh.feature_extraction.settings.ReasonableFeatureExtractionSettings`: Mostly the same features as in the
-  :class:`tsfresh.feature_extraction.settings.FeatureExtractionSettings`, except a few exception, which are marked as
+* :class:`tsfresh.feature_extraction.settings.EfficientFCParameters`: Mostly the same features as in the
+  :class:`tsfresh.feature_extraction.settings.ComprehensiveFCParameters`, except a few exception, which are marked as
   high_comp_cost. This can be used if runtime performance plays a major role.
 
 It is also possible, to control the features to be extracted for the different kinds of time series individually.

--- a/docs/text/feature_extraction_settings.rst
+++ b/docs/text/feature_extraction_settings.rst
@@ -4,8 +4,8 @@ Feature extraction settings
 In most of the cases - especially when you play around with the data and do data mining -
 you probably want to extract all typical features when you call the :func:`tsfresh.extract_features`
 function and select only the relevant features later. Then you can call the function
-:func:`tsfresh.extract_features` without passing a `default_calculation_settings_mapping` or
-`kind_to_calculation_settings_mapping` object, which means you are using the default options (which will use all
+:func:`tsfresh.extract_features` without passing a `default_para_map` or
+`kind_to_para_map` object, which means you are using the default options (which will use all
 feature calculators in this package).
 
 After digging deeper into your data, you maybe want to calculate more of a certain type of feature and less of another
@@ -17,10 +17,10 @@ custom settings object, like shown now:
 >>> # Set here the options of the settings object as shown in the chapters below
 >>> # ...
 >>> from tsfresh.feature_extraction import extract_features
->>> extract_features(df, default_calculation_settings_mapping=settings)
+>>> extract_features(df, default_para_map=settings)
 
 
-The `default_calculation_settings_mapping` is expected to be a dictionary, which maps feature calculator names
+The `default_para_map` is expected to be a dictionary, which maps feature calculator names
 (the function names you can find in the :mod:`tsfresh.feature_extraction.feature_calculators` file) to a list
 of dictionaries, which are the parameters with which the function will be called (as key value pairs). Each function
 parameter combination, that is in this dict will be called during the extraction and will produce a feature.
@@ -30,7 +30,7 @@ For example
 
 .. code:: python
 
-    calculation_settings_mapping = {
+    para_map = {
         "length": None,
         "large_standard_deviation": [{"r": 0.05}, {"r": 0.1}]
     }
@@ -45,7 +45,7 @@ For convenience, there are already three dict predefined, which can be used righ
 
 * :class:`tsfresh.feature_extraction.settings.FeatureExtractionSettings`: includes all features without parameters and
   all features will parameters, with quite some different parameter combinations. This is the default of you do not
-  hand in a `default_calculation_settings_mapping` at all.
+  hand in a `default_para_map` at all.
 * :class:`tsfresh.feature_extraction.settings.MinimalFeatureExtractionSettings`: includes only few features
   and can be used for quick tests. The features which have the "minimal" attribute are used here.
 * :class:`tsfresh.feature_extraction.settings.ReasonableFeatureExtractionSettings`: Mostly the same features as in the
@@ -55,14 +55,14 @@ For convenience, there are already three dict predefined, which can be used righ
 It is also possible, to control the features to be extracted for the different kinds of time series individually.
 You can do so by passing another dictionary to the extract function as a
 
-`kind_to_calculation_settings_mapping` = {"kind" : `calculation_settings_mapping`}
+`kind_to_para_map` = {"kind" : `para_map`}
 
-parameter. This dict must be a mapping from kind names (as string) to `calculation_settings_mapping` objects,
-which you would normally pass as an argument to the `default_calculation_settings_mapping` parameter.
+parameter. This dict must be a mapping from kind names (as string) to `para_map` objects,
+which you would normally pass as an argument to the `default_para_map` parameter.
 
-This dominating behavior of the `kind_to_calculation_settings_mapping` argument works partly. So, if you include a kind
-name in the `kind_to_calculation_settings_mapping` parameter, its value will override the
-`default_calculation_settings_mapping`. Otherwise, the `default_calculation_settings_mapping` if the kind name could
+This dominating behavior of the `kind_to_para_map` argument works partly. So, if you include a kind
+name in the `kind_to_para_map` parameter, its value will override the
+`default_para_map`. Otherwise, the `default_para_map` if the kind name could
 not be found.
 
 

--- a/docs/text/feature_extraction_settings.rst
+++ b/docs/text/feature_extraction_settings.rst
@@ -4,8 +4,8 @@ Feature extraction settings
 In most of the cases - especially when you play around with the data and do data mining -
 you probably want to extract all typical features when you call the :func:`tsfresh.extract_features`
 function and select only the relevant features later. Then you can call the function
-:func:`tsfresh.extract_features` without passing a `default_para_map` or
-`kind_to_para_map` object, which means you are using the default options (which will use all
+:func:`tsfresh.extract_features` without passing a `default_fc_parameters` or
+`kind_to_fc_parameters` object, which means you are using the default options (which will use all
 feature calculators in this package).
 
 After digging deeper into your data, you maybe want to calculate more of a certain type of feature and less of another
@@ -17,7 +17,7 @@ custom settings object, like shown now:
 >>> # Set here the options of the settings object as shown in the chapters below
 >>> # ...
 >>> from tsfresh.feature_extraction import extract_features
->>> extract_features(df, default_para_map=settings)
+>>> extract_features(df, default_fc_parameters=settings)
 
 
 The
@@ -32,7 +32,7 @@ custom settings object, like shown now:
 >>> # Set here the options of the settings object as shown in the chapters below
 >>> # ...
 >>> from tsfresh.feature_extraction import extract_features
->>> extract_features(df, default_para_map=settings)
+>>> extract_features(df, default_fc_parameters=settings)
 
 
 The
@@ -47,10 +47,10 @@ custom settings object, like shown now:
 >>> # Set here the options of the settings object as shown in the chapters below
 >>> # ...
 >>> from tsfresh.feature_extraction import extract_features
->>> extract_features(df, default_para_map=settings)
+>>> extract_features(df, default_fc_parameters=settings)
 
 
-The `default_para_map` is expected to be a dictionary, which maps feature calculator names
+The `default_fc_parameters` is expected to be a dictionary, which maps feature calculator names
 (the function names you can find in the :mod:`tsfresh.feature_extraction.feature_calculators` file) to a list
 of dictionaries, which are the parameters with which the function will be called (as key value pairs). Each function
 parameter combination, that is in this dict will be called during the extraction and will produce a feature.
@@ -60,7 +60,7 @@ For example
 
 .. code:: python
 
-    para_map = {
+    fc_parameters = {
         "length": None,
         "large_standard_deviation": [{"r": 0.05}, {"r": 0.1}]
     }
@@ -75,7 +75,7 @@ For convenience, there are already three dict predefined, which can be used righ
 
 * :class:`tsfresh.feature_extraction.settings.ComprehensiveFCParameters`: includes all features without parameters and
   all features will parameters, with quite some different parameter combinations. This is the default of you do not
-  hand in a `default_para_map` at all.
+  hand in a `default_fc_parameters` at all.
 * :class:`tsfresh.feature_extraction.settings.MinimalFCParameters`: includes only few features
   and can be used for quick tests. The features which have the "minimal" attribute are used here.
 * :class:`tsfresh.feature_extraction.settings.EfficientFCParameters`: Mostly the same features as in the
@@ -85,14 +85,14 @@ For convenience, there are already three dict predefined, which can be used righ
 It is also possible, to control the features to be extracted for the different kinds of time series individually.
 You can do so by passing another dictionary to the extract function as a
 
-`kind_to_para_map` = {"kind" : `para_map`}
+`kind_to_fc_parameters` = {"kind" : `fc_parameters`}
 
-parameter. This dict must be a mapping from kind names (as string) to `para_map` objects,
-which you would normally pass as an argument to the `default_para_map` parameter.
+parameter. This dict must be a mapping from kind names (as string) to `fc_parameters` objects,
+which you would normally pass as an argument to the `default_fc_parameters` parameter.
 
-This dominating behavior of the `kind_to_para_map` argument works partly. So, if you include a kind
-name in the `kind_to_para_map` parameter, its value will override the
-`default_para_map`. Otherwise, the `default_para_map` if the kind name could
+This dominating behavior of the `kind_to_fc_parameters` argument works partly. So, if you include a kind
+name in the `kind_to_fc_parameters` parameter, its value will override the
+`default_fc_parameters`. Otherwise, the `default_fc_parameters` if the kind name could
 not be found.
 
 

--- a/docs/text/how_to_add_custom_feature.rst
+++ b/docs/text/how_to_add_custom_feature.rst
@@ -107,7 +107,7 @@ Step 3. Add custom settings for your feature
 
 Finally, you have to add custom settings if your feature is a apply or aggregate feature with parameters. To do so,
 just append your parameters to the ``name_to_param`` dictionary inside the
-:class:`tsfresh.feature_extraction.settings.FeatureExtractionSettings` constructor:
+:class:`tsfresh.EfficientFCParameters` constructor:
 
 .. code:: python
 
@@ -122,9 +122,9 @@ just append your parameters to the ``name_to_param`` dictionary inside the
 That is it, tsfresh will calculate your feature the next time you run it.
 
 Please make sure, that the different feature extraction settings
-(e.g. :class:`tsfresh.feature_extraction.settings.FeatureExtractionSettings`,
-:class:`tsfresh.feature_extraction.settings.MinimalFeatureExtractionSettings` or
-:class:`tsfresh.feature_extraction.settings.ReasonableFeatureExtractionSettings`) do include different sets of
+(e.g. :class:`tsfresh.feature_extraction.settings.EfficientCParameters`,
+:class:`tsfresh.feature_extraction.settings.MinimalFCParameters` or
+:class:`tsfresh.feature_extraction.settings.ComprehensiveFCParameters`) do include different sets of
 feature calculators to use. You can control, which feature extraction settings object will include your new
 feature calculator by giving your function attributes like "minimal" or "high_comp_cost". Please see the
 classes in :mod:`tsfresh.feature_extraction.settings` for more information.

--- a/notebooks/compare-runtimes-of-feature-calculators.ipynb
+++ b/notebooks/compare-runtimes-of-feature-calculators.ipynb
@@ -510,7 +510,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -521,5 +521,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/notebooks/human_acitivity_recognition_example.ipynb
+++ b/notebooks/human_acitivity_recognition_example.ipynb
@@ -249,7 +249,9 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -261,7 +263,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -272,5 +274,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/notebooks/pipeline_example.ipynb
+++ b/notebooks/pipeline_example.ipynb
@@ -126,7 +126,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -137,5 +137,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/notebooks/robot_failure_example.ipynb
+++ b/notebooks/robot_failure_example.ipynb
@@ -270,7 +270,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -281,5 +281,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/tests/feature_extraction/test_extraction.py
+++ b/tests/feature_extraction/test_extraction.py
@@ -78,7 +78,7 @@ class ExtractionTestCase(DataTestCase):
         settings = ComprehensiveFCParameters()
 
         extracted_features = _extract_features_for_one_time_series(["b", df.loc[df.kind == "b", ["val", "id"]]],
-                                                                   default_para_map=settings,
+                                                                   default_fc_parameters=settings,
                                                                    column_value="val", column_id="id")
 
         self.assertIsInstance(extracted_features, pd.DataFrame)
@@ -90,7 +90,7 @@ class ExtractionTestCase(DataTestCase):
 
         df_sts = self.create_one_valued_time_series()
         extracted_features_sts = _extract_features_for_one_time_series(["a", df_sts[["val", "id"]]],
-                                                                       default_para_map=settings,
+                                                                       default_fc_parameters=settings,
                                                                        column_value="val", column_id="id")
 
         self.assertIsInstance(extracted_features_sts, pd.DataFrame)

--- a/tests/feature_extraction/test_extraction.py
+++ b/tests/feature_extraction/test_extraction.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from tests.fixtures import DataTestCase
 from tsfresh.feature_extraction.extraction import extract_features, _extract_features_for_one_time_series
-from tsfresh.feature_extraction.settings import FeatureExtractionSettings
+from tsfresh.feature_extraction.settings import ComprehensiveFCParameters
 import six
 import os
 
@@ -75,7 +75,7 @@ class ExtractionTestCase(DataTestCase):
     def test_extract_features_for_one_time_series(self):
         # todo: implement more methods and test more aspects
         df = self.create_test_data_sample()
-        settings = FeatureExtractionSettings()
+        settings = ComprehensiveFCParameters()
 
         extracted_features = _extract_features_for_one_time_series(["b", df.loc[df.kind == "b", ["val", "id"]]],
                                                                    default_para_map=settings,

--- a/tests/feature_extraction/test_extraction.py
+++ b/tests/feature_extraction/test_extraction.py
@@ -78,7 +78,7 @@ class ExtractionTestCase(DataTestCase):
         settings = FeatureExtractionSettings()
 
         extracted_features = _extract_features_for_one_time_series(["b", df.loc[df.kind == "b", ["val", "id"]]],
-                                                                   default_calculation_settings_mapping=settings,
+                                                                   default_para_map=settings,
                                                                    column_value="val", column_id="id")
 
         self.assertIsInstance(extracted_features, pd.DataFrame)
@@ -90,7 +90,7 @@ class ExtractionTestCase(DataTestCase):
 
         df_sts = self.create_one_valued_time_series()
         extracted_features_sts = _extract_features_for_one_time_series(["a", df_sts[["val", "id"]]],
-                                                                       default_calculation_settings_mapping=settings,
+                                                                       default_para_map=settings,
                                                                        column_value="val", column_id="id")
 
         self.assertIsInstance(extracted_features_sts, pd.DataFrame)

--- a/tests/feature_extraction/test_settings.py
+++ b/tests/feature_extraction/test_settings.py
@@ -8,20 +8,20 @@ from unittest import TestCase
 import numpy as np
 import pandas as pd
 from tsfresh.feature_extraction.extraction import extract_features, _extract_features_for_one_time_series
-from tsfresh.feature_extraction.settings import FeatureExtractionSettings, MinimalFeatureExtractionSettings,\
-    ReasonableFeatureExtractionSettings, from_columns
+from tsfresh.feature_extraction.settings import ComprehensiveFCParameters, MinimalFCParameters,\
+    EfficientFCParameters, from_columns
 import six
 from tsfresh.feature_extraction import feature_calculators
 
 
 class TestSettingsObject(TestCase):
     """
-    This tests the base class FeatureExtractionSettings
+    This tests the base class ComprehensiveFCParameters
     """
     def test_from_columns(self):
         tsn = "TEST_TIME_SERIES"
 
-        fset = FeatureExtractionSettings()
+        fset = ComprehensiveFCParameters()
         self.assertRaises(TypeError, from_columns, 42)
         self.assertRaises(TypeError, from_columns, 42)
         self.assertRaises(ValueError, from_columns, ["This is not a column name"])
@@ -55,27 +55,26 @@ class TestSettingsObject(TestCase):
 
     def test_default_calculates_all_features(self):
         """
-        Test that by default a FeatureExtractionSettings object should be set up to calculate all features defined
+        Test that by default a ComprehensiveFCParameters object should be set up to calculate all features defined
         in tsfresh.feature_extraction.feature_calculators
         """
-        settings = FeatureExtractionSettings()
+        settings = ComprehensiveFCParameters()
         all_feature_calculators = [name for name, func in feature_calculators.__dict__.items()
                                    if hasattr(func, "fctype")]
 
         for calculator in all_feature_calculators:
             self.assertIn(calculator, settings,
-                          msg='Default FeatureExtractionSettings object does not setup calculation of {}'
+                          msg='Default ComprehensiveFCParameters object does not setup calculation of {}'
                           .format(calculator))
 
 
-class TestReasonableFeatureExtractionSettings(TestCase):
+class TestEfficientFCParameters(TestCase):
     """
-    This tests the ReasonableFeatureExtractionSettings class
+    This tests the EfficientFCParameters( class
     """
 
     def test_extraction_runs_through(self):
-        rfs = ReasonableFeatureExtractionSettings()
-
+        rfs = EfficientFCParameters()
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
 
         extracted_features = extract_features(data, default_para_map=rfs,
@@ -86,22 +85,22 @@ class TestReasonableFeatureExtractionSettings(TestCase):
 
     def test_contains_all_non_high_comp_cost_features(self):
         """
-        Test that by default a FeatureExtractionSettings object should be set up to calculate all features defined
+        Test that by default a EfficientFCParameters object should be set up to calculate all features defined
         in tsfresh.feature_extraction.feature_calculators that do not have the attribute "high_comp_cost"
         """
-        rfs = ReasonableFeatureExtractionSettings()
+        rfs = EfficientFCParameters()
         all_feature_calculators = [name for name, func in feature_calculators.__dict__.items()
                                    if hasattr(func, "fctype") and not hasattr(func, "high_comp_cost")]
 
         for calculator in all_feature_calculators:
             self.assertIn(calculator, rfs,
-                          msg='Default FeatureExtractionSettings object does not setup calculation of {}'
+                          msg='Default EfficientFCParameters object does not setup calculation of {}'
                           .format(calculator))
 
 
 class TestMinimalSettingsObject(TestCase):
     def test_all_minimal_features_in(self):
-        mfs = MinimalFeatureExtractionSettings()
+        mfs = MinimalFCParameters()
 
         self.assertIn("mean", mfs)
         self.assertIn("median", mfs)
@@ -113,7 +112,7 @@ class TestMinimalSettingsObject(TestCase):
         self.assertIn("variance", mfs)
 
     def test_extraction_runs_through(self):
-        mfs = MinimalFeatureExtractionSettings()
+        mfs = MinimalFCParameters()
 
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
 
@@ -127,7 +126,7 @@ class TestMinimalSettingsObject(TestCase):
         six.assertCountEqual(self, extracted_features.index, [0, 1])
 
     def test_extraction_for_one_time_series_runs_through(self):
-        mfs = MinimalFeatureExtractionSettings()
+        mfs = MinimalFCParameters()
 
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
         extracted_features = _extract_features_for_one_time_series([0, data],

--- a/tests/feature_extraction/test_settings.py
+++ b/tests/feature_extraction/test_settings.py
@@ -40,17 +40,17 @@ class TestSettingsObject(TestCase):
         # Apply functions
         feature_names += [tsn + '__ar_coefficient__k_20__coeff_4', tsn + '__ar_coefficient__coeff_10__k_-1']
 
-        kind_to_para_map = from_columns(feature_names)
+        kind_to_fc_parameters = from_columns(feature_names)
 
-        six.assertCountEqual(self, list(kind_to_para_map[tsn].keys()),
+        six.assertCountEqual(self, list(kind_to_fc_parameters[tsn].keys()),
           ["sum_values", "median", "length", "sample_entropy", "quantile", "number_peaks", "ar_coefficient",
                                   "value_count"])
         
-        self.assertEqual(kind_to_para_map[tsn]["sum_values"], None)
-        self.assertEqual(kind_to_para_map[tsn]["ar_coefficient"],
+        self.assertEqual(kind_to_fc_parameters[tsn]["sum_values"], None)
+        self.assertEqual(kind_to_fc_parameters[tsn]["ar_coefficient"],
                          [{"k": 20, "coeff": 4}, {"k": -1, "coeff": 10}])
 
-        self.assertEqual(kind_to_para_map[tsn]["value_count"],
+        self.assertEqual(kind_to_fc_parameters[tsn]["value_count"],
                          [{"value": np.PINF}, {"value": np.NINF}, {"value": np.NaN}])
 
     def test_default_calculates_all_features(self):
@@ -77,7 +77,7 @@ class TestEfficientFCParameters(TestCase):
         rfs = EfficientFCParameters()
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
 
-        extracted_features = extract_features(data, default_para_map=rfs,
+        extracted_features = extract_features(data, default_fc_parameters=rfs,
                                               column_kind="kind", column_value="value",
                                               column_sort="time", column_id="id")
 
@@ -116,7 +116,7 @@ class TestMinimalSettingsObject(TestCase):
 
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
 
-        extracted_features = extract_features(data, default_para_map=mfs,
+        extracted_features = extract_features(data, default_fc_parameters=mfs,
                                               column_kind="kind", column_value="value",
                                               column_sort="time", column_id="id")
 
@@ -130,7 +130,7 @@ class TestMinimalSettingsObject(TestCase):
 
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
         extracted_features = _extract_features_for_one_time_series([0, data],
-                                                                   default_para_map=mfs,
+                                                                   default_fc_parameters=mfs,
                                                                    column_value="value", column_id="id")
         six.assertCountEqual(self, extracted_features.columns,
                              ["0__median", "0__standard_deviation", "0__sum_values", "0__maximum", "0__variance",

--- a/tests/feature_extraction/test_settings.py
+++ b/tests/feature_extraction/test_settings.py
@@ -40,17 +40,17 @@ class TestSettingsObject(TestCase):
         # Apply functions
         feature_names += [tsn + '__ar_coefficient__k_20__coeff_4', tsn + '__ar_coefficient__coeff_10__k_-1']
 
-        kind_to_calculation_settings_mapping = from_columns(feature_names)
+        kind_to_para_map = from_columns(feature_names)
 
-        six.assertCountEqual(self, list(kind_to_calculation_settings_mapping[tsn].keys()),
+        six.assertCountEqual(self, list(kind_to_para_map[tsn].keys()),
           ["sum_values", "median", "length", "sample_entropy", "quantile", "number_peaks", "ar_coefficient",
                                   "value_count"])
         
-        self.assertEqual(kind_to_calculation_settings_mapping[tsn]["sum_values"], None)
-        self.assertEqual(kind_to_calculation_settings_mapping[tsn]["ar_coefficient"],
+        self.assertEqual(kind_to_para_map[tsn]["sum_values"], None)
+        self.assertEqual(kind_to_para_map[tsn]["ar_coefficient"],
                          [{"k": 20, "coeff": 4}, {"k": -1, "coeff": 10}])
 
-        self.assertEqual(kind_to_calculation_settings_mapping[tsn]["value_count"],
+        self.assertEqual(kind_to_para_map[tsn]["value_count"],
                          [{"value": np.PINF}, {"value": np.NINF}, {"value": np.NaN}])
 
     def test_default_calculates_all_features(self):
@@ -78,7 +78,7 @@ class TestReasonableFeatureExtractionSettings(TestCase):
 
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
 
-        extracted_features = extract_features(data, default_calculation_settings_mapping=rfs,
+        extracted_features = extract_features(data, default_para_map=rfs,
                                               column_kind="kind", column_value="value",
                                               column_sort="time", column_id="id")
 
@@ -117,7 +117,7 @@ class TestMinimalSettingsObject(TestCase):
 
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
 
-        extracted_features = extract_features(data, default_calculation_settings_mapping=mfs,
+        extracted_features = extract_features(data, default_para_map=mfs,
                                               column_kind="kind", column_value="value",
                                               column_sort="time", column_id="id")
 
@@ -131,7 +131,7 @@ class TestMinimalSettingsObject(TestCase):
 
         data = pd.DataFrame([[0, 0, 0, 0], [1, 0, 0, 0]], columns=["id", "time", "kind", "value"])
         extracted_features = _extract_features_for_one_time_series([0, data],
-                                                                   default_calculation_settings_mapping=mfs,
+                                                                   default_para_map=mfs,
                                                                    column_value="value", column_id="id")
         six.assertCountEqual(self, extracted_features.columns,
                              ["0__median", "0__standard_deviation", "0__sum_values", "0__maximum", "0__variance",

--- a/tests/test_relevant_feature_extraction.py
+++ b/tests/test_relevant_feature_extraction.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division
 from tests.fixtures import DataTestCase
 from tsfresh import extract_features, select_features, extract_relevant_features
-from tsfresh.feature_extraction.settings import FeatureExtractionSettings
+from tsfresh.feature_extraction.settings import ComprehensiveFCParameters
 from tsfresh.utilities.dataframe_functions import impute
 from unittest import TestCase
 import numpy as np

--- a/tests/transformers/test_feature_augmenter.py
+++ b/tests/transformers/test_feature_augmenter.py
@@ -5,7 +5,7 @@
 from __future__ import print_function
 import pandas as pd
 from tests.fixtures import DataTestCase
-from tsfresh.feature_extraction.settings import FeatureExtractionSettings
+from tsfresh.feature_extraction.settings import ComprehensiveFCParameters
 from tsfresh.transformers import FeatureAugmenter
 import six
 import numpy as np

--- a/tests/transformers/test_feature_augmenter.py
+++ b/tests/transformers/test_feature_augmenter.py
@@ -14,14 +14,14 @@ class FeatureAugmenterTestCase(DataTestCase):
     def setUp(self):
         self.test_df = self.create_test_data_sample()
 
-        calculation_settings_mapping = {"length": None}
-        self.kind_to_calculation_settings_mapping = {"a": calculation_settings_mapping.copy(),
-                                                     "b": calculation_settings_mapping.copy()}
+        para_map = {"length": None}
+        self.kind_to_para_map = {"a": para_map.copy(),
+                                                     "b": para_map.copy()}
 
     def test_fit_and_transform(self):
         augmenter = FeatureAugmenter(column_value="val", column_id="id", column_sort="sort",
                                      column_kind="kind",
-                                     kind_to_calculation_settings_mapping=self.kind_to_calculation_settings_mapping)
+                                     kind_to_para_map=self.kind_to_para_map)
 
         # Fit should do nothing
         returned_df = augmenter.fit()
@@ -55,7 +55,7 @@ class FeatureAugmenterTestCase(DataTestCase):
     def test_add_features_to_only_a_part(self):
         augmenter = FeatureAugmenter(column_value="val", column_id="id", column_sort="sort",
                                      column_kind="kind",
-                                     kind_to_calculation_settings_mapping=self.kind_to_calculation_settings_mapping)
+                                     kind_to_para_map=self.kind_to_para_map)
 
         augmenter.set_timeseries_container(self.test_df)
 

--- a/tests/transformers/test_feature_augmenter.py
+++ b/tests/transformers/test_feature_augmenter.py
@@ -14,14 +14,14 @@ class FeatureAugmenterTestCase(DataTestCase):
     def setUp(self):
         self.test_df = self.create_test_data_sample()
 
-        para_map = {"length": None}
-        self.kind_to_para_map = {"a": para_map.copy(),
-                                                     "b": para_map.copy()}
+        fc_parameters = {"length": None}
+        self.kind_to_fc_parameters = {"a": fc_parameters.copy(),
+                                                     "b": fc_parameters.copy()}
 
     def test_fit_and_transform(self):
         augmenter = FeatureAugmenter(column_value="val", column_id="id", column_sort="sort",
                                      column_kind="kind",
-                                     kind_to_para_map=self.kind_to_para_map)
+                                     kind_to_fc_parameters=self.kind_to_fc_parameters)
 
         # Fit should do nothing
         returned_df = augmenter.fit()
@@ -55,7 +55,7 @@ class FeatureAugmenterTestCase(DataTestCase):
     def test_add_features_to_only_a_part(self):
         augmenter = FeatureAugmenter(column_value="val", column_id="id", column_sort="sort",
                                      column_kind="kind",
-                                     kind_to_para_map=self.kind_to_para_map)
+                                     kind_to_fc_parameters=self.kind_to_fc_parameters)
 
         augmenter.set_timeseries_container(self.test_df)
 

--- a/tests/transformers/test_relevant_feature_extractor.py
+++ b/tests/transformers/test_relevant_feature_extractor.py
@@ -4,7 +4,7 @@
 
 import pandas as pd
 from tests.fixtures import DataTestCase
-from tsfresh.feature_extraction import FeatureExtractionSettings
+from tsfresh.feature_extraction import ComprehensiveFCParameters
 from tsfresh.transformers.relevant_feature_augmenter import RelevantFeatureAugmenter
 
 

--- a/tests/transformers/test_relevant_feature_extractor.py
+++ b/tests/transformers/test_relevant_feature_extractor.py
@@ -11,9 +11,9 @@ from tsfresh.transformers.relevant_feature_augmenter import RelevantFeatureAugme
 class RelevantFeatureAugmenterTestCase(DataTestCase):
     def setUp(self):
         self.test_df = self.create_test_data_sample()
-        calculation_settings_mapping = {"length": None}
-        self.kind_to_calculation_settings_mapping = {"a": calculation_settings_mapping.copy(),
-                                                     "b": calculation_settings_mapping.copy()}
+        para_map = {"length": None}
+        self.kind_to_para_map = {"a": para_map.copy(),
+                                                     "b": para_map.copy()}
 
     def test_not_fitted(self):
         augmenter = RelevantFeatureAugmenter()
@@ -31,7 +31,7 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         self.assertRaises(RuntimeError, augmenter.fit, X, y)
 
     def test_nothing_relevant(self):
-        augmenter = RelevantFeatureAugmenter(kind_to_calculation_settings_mapping=self.kind_to_calculation_settings_mapping,
+        augmenter = RelevantFeatureAugmenter(kind_to_para_map=self.kind_to_para_map,
                                              column_value="val", column_id="id", column_sort="sort",
                                              column_kind="kind")
 
@@ -47,9 +47,9 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         self.assertEqual(list(transformed_X.index), list(X.index))
 
     def test_impute_works(self):
-        self.kind_to_calculation_settings_mapping["a"].update({"kurtosis": None})
+        self.kind_to_para_map["a"].update({"kurtosis": None})
 
-        augmeter = RelevantFeatureAugmenter(kind_to_calculation_settings_mapping=self.kind_to_calculation_settings_mapping,
+        augmeter = RelevantFeatureAugmenter(kind_to_para_map=self.kind_to_para_map,
                                             column_value="val", column_id="id", column_sort="sort",
                                             column_kind="kind")
 

--- a/tests/transformers/test_relevant_feature_extractor.py
+++ b/tests/transformers/test_relevant_feature_extractor.py
@@ -11,9 +11,9 @@ from tsfresh.transformers.relevant_feature_augmenter import RelevantFeatureAugme
 class RelevantFeatureAugmenterTestCase(DataTestCase):
     def setUp(self):
         self.test_df = self.create_test_data_sample()
-        para_map = {"length": None}
-        self.kind_to_para_map = {"a": para_map.copy(),
-                                                     "b": para_map.copy()}
+        fc_parameters = {"length": None}
+        self.kind_to_fc_parameters = {"a": fc_parameters.copy(),
+                                                     "b": fc_parameters.copy()}
 
     def test_not_fitted(self):
         augmenter = RelevantFeatureAugmenter()
@@ -31,7 +31,7 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         self.assertRaises(RuntimeError, augmenter.fit, X, y)
 
     def test_nothing_relevant(self):
-        augmenter = RelevantFeatureAugmenter(kind_to_para_map=self.kind_to_para_map,
+        augmenter = RelevantFeatureAugmenter(kind_to_fc_parameters=self.kind_to_fc_parameters,
                                              column_value="val", column_id="id", column_sort="sort",
                                              column_kind="kind")
 
@@ -47,9 +47,9 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         self.assertEqual(list(transformed_X.index), list(X.index))
 
     def test_impute_works(self):
-        self.kind_to_para_map["a"].update({"kurtosis": None})
+        self.kind_to_fc_parameters["a"].update({"kurtosis": None})
 
-        augmeter = RelevantFeatureAugmenter(kind_to_para_map=self.kind_to_para_map,
+        augmeter = RelevantFeatureAugmenter(kind_to_fc_parameters=self.kind_to_fc_parameters,
                                             column_value="val", column_id="id", column_sort="sort",
                                             column_kind="kind")
 

--- a/tsfresh/convenience/relevant_extraction.py
+++ b/tsfresh/convenience/relevant_extraction.py
@@ -51,7 +51,7 @@ def extract_relevant_features(timeseries_container, y, X=None,
     :type y: pandas.Series
 
     :param default_para_map: mapping from feature calculator names to parameters. Only those names
-           which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
+           which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
     :type default_para_map: dict
 

--- a/tsfresh/convenience/relevant_extraction.py
+++ b/tsfresh/convenience/relevant_extraction.py
@@ -11,8 +11,8 @@ from tsfresh.utilities.dataframe_functions import restrict_input_to_index, imput
 
 
 def extract_relevant_features(timeseries_container, y, X=None,
-                              default_calculation_settings_mapping=None,
-                              kind_to_calculation_settings_mapping=None,
+                              default_para_map=None,
+                              kind_to_para_map=None,
                               column_id=None, column_sort=None, column_kind=None, column_value=None,
                               parallelization=defaults.PARALLELISATION, show_warnings=defaults.SHOW_WARNINGS,
                               disable_progressbar=defaults.DISABLE_PROGRESSBAR,
@@ -50,15 +50,15 @@ def extract_relevant_features(timeseries_container, y, X=None,
     :param y: The target vector
     :type y: pandas.Series
 
-    :param default_calculation_settings_mapping: mapping from feature calculator names to parameters. Only those names
+    :param default_para_map: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
            more information.
-    :type default_calculation_settings_mapping: dict
+    :type default_para_map: dict
 
-    :param kind_to_calculation_settings_mapping: mapping from kind names to objects of the same type as the ones for
-            default_calculation_settings_mapping. If you put a kind as a key here, the calculation_settings_mapping
-            object (which is the value), will be used instead of the default_calculation_settings_mapping.
-    :type kind_to_calculation_settings_mapping: dict
+    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
+            default_para_map. If you put a kind as a key here, the para_map
+            object (which is the value), will be used instead of the default_para_map.
+    :type kind_to_para_map: dict
 
     :param column_id: The name of the id column to group by.
     :type column_id: str
@@ -136,8 +136,8 @@ def extract_relevant_features(timeseries_container, y, X=None,
         timeseries_container = restrict_input_to_index(timeseries_container, column_id, X.index)
 
     X_ext = extract_features(timeseries_container,
-                             default_calculation_settings_mapping=default_calculation_settings_mapping,
-                             kind_to_calculation_settings_mapping=kind_to_calculation_settings_mapping,
+                             default_para_map=default_para_map,
+                             kind_to_para_map=kind_to_para_map,
                              parallelization=parallelization, show_warnings=show_warnings,
                              disable_progressbar=disable_progressbar,
                              profile=profile,

--- a/tsfresh/convenience/relevant_extraction.py
+++ b/tsfresh/convenience/relevant_extraction.py
@@ -11,8 +11,8 @@ from tsfresh.utilities.dataframe_functions import restrict_input_to_index, imput
 
 
 def extract_relevant_features(timeseries_container, y, X=None,
-                              default_para_map=None,
-                              kind_to_para_map=None,
+                              default_fc_parameters=None,
+                              kind_to_fc_parameters=None,
                               column_id=None, column_sort=None, column_kind=None, column_value=None,
                               parallelization=defaults.PARALLELISATION, show_warnings=defaults.SHOW_WARNINGS,
                               disable_progressbar=defaults.DISABLE_PROGRESSBAR,
@@ -50,15 +50,15 @@ def extract_relevant_features(timeseries_container, y, X=None,
     :param y: The target vector
     :type y: pandas.Series
 
-    :param default_para_map: mapping from feature calculator names to parameters. Only those names
+    :param default_fc_parameters: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
-    :type default_para_map: dict
+    :type default_fc_parameters: dict
 
-    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
-            default_para_map. If you put a kind as a key here, the para_map
-            object (which is the value), will be used instead of the default_para_map.
-    :type kind_to_para_map: dict
+    :param kind_to_fc_parameters: mapping from kind names to objects of the same type as the ones for
+            default_fc_parameters. If you put a kind as a key here, the fc_parameters
+            object (which is the value), will be used instead of the default_fc_parameters.
+    :type kind_to_fc_parameters: dict
 
     :param column_id: The name of the id column to group by.
     :type column_id: str
@@ -136,8 +136,8 @@ def extract_relevant_features(timeseries_container, y, X=None,
         timeseries_container = restrict_input_to_index(timeseries_container, column_id, X.index)
 
     X_ext = extract_features(timeseries_container,
-                             default_para_map=default_para_map,
-                             kind_to_para_map=kind_to_para_map,
+                             default_fc_parameters=default_fc_parameters,
+                             kind_to_fc_parameters=kind_to_fc_parameters,
                              parallelization=parallelization, show_warnings=show_warnings,
                              disable_progressbar=disable_progressbar,
                              profile=profile,

--- a/tsfresh/feature_extraction/__init__.py
+++ b/tsfresh/feature_extraction/__init__.py
@@ -3,5 +3,5 @@ The :mod:`tsfresh.feature_extraction` module contains methods to extract the fea
 """
 
 from tsfresh.feature_extraction.extraction import extract_features
-from tsfresh.feature_extraction.settings import FeatureExtractionSettings, MinimalFeatureExtractionSettings, \
-    ReasonableFeatureExtractionSettings
+from tsfresh.feature_extraction.settings import ComprehensiveFCParameters, MinimalFCParameters, \
+    EfficientFCParameters

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -24,8 +24,8 @@ from tsfresh.utilities import dataframe_functions, profiling
 _logger = logging.getLogger(__name__)
 
 
-def extract_features(timeseries_container, default_calculation_settings_mapping=None,
-                     kind_to_calculation_settings_mapping=None,
+def extract_features(timeseries_container, default_para_map=None,
+                     kind_to_para_map=None,
                      column_id=None, column_sort=None, column_kind=None, column_value=None,
                      parallelization=None, chunksize=tsfresh.defaults.CHUNKSIZE,
                      n_processes=tsfresh.defaults.N_PROCESSES, show_warnings=tsfresh.defaults.SHOW_WARNINGS,
@@ -66,15 +66,15 @@ def extract_features(timeseries_container, default_calculation_settings_mapping=
             dictionary of pandas.DataFrames.
     :type timeseries_container: pandas.DataFrame or dict
 
-    :param default_calculation_settings_mapping: mapping from feature calculator names to parameters. Only those names
+    :param default_para_map: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
            more information.
-    :type default_calculation_settings_mapping: dict
+    :type default_para_map: dict
 
-    :param kind_to_calculation_settings_mapping: mapping from kind names to objects of the same type as the ones for
-            default_calculation_settings_mapping. If you put a kind as a key here, the calculation_settings_mapping
-            object (which is the value), will be used instead of the default_calculation_settings_mapping.
-    :type kind_to_calculation_settings_mapping: dict
+    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
+            default_para_map. If you put a kind as a key here, the para_map
+            object (which is the value), will be used instead of the default_para_map.
+    :type kind_to_para_map: dict
 
     :param column_id: The name of the id column to group by.
     :type column_id: str
@@ -131,8 +131,8 @@ def extract_features(timeseries_container, default_calculation_settings_mapping=
                                                                        column_kind, column_value)
 
     # Use the standard setting if the user did not supply ones himself.
-    if default_calculation_settings_mapping is None:
-        default_calculation_settings_mapping = FeatureExtractionSettings()
+    if default_para_map is None:
+        default_para_map = FeatureExtractionSettings()
 
     # Choose the parallelization according to a rule-of-thumb
     if parallelization is None:
@@ -153,8 +153,8 @@ def extract_features(timeseries_container, default_calculation_settings_mapping=
         raise ValueError("Argument parallelization must be one of: 'per_kind', 'per_sample'")
 
     result = calculation_function(kind_to_df_map,
-                                  default_calculation_settings_mapping=default_calculation_settings_mapping,
-                                  kind_to_calculation_settings_mapping=kind_to_calculation_settings_mapping,
+                                  default_para_map=default_para_map,
+                                  kind_to_para_map=kind_to_para_map,
                                   column_id=column_id,
                                   column_value=column_value,
                                   chunksize=chunksize,
@@ -174,8 +174,8 @@ def extract_features(timeseries_container, default_calculation_settings_mapping=
 
 def _extract_features_parallel_per_kind(kind_to_df_map,
                                         column_id, column_value,
-                                        default_calculation_settings_mapping,
-                                        kind_to_calculation_settings_mapping=None,
+                                        default_para_map,
+                                        kind_to_para_map=None,
                                         chunksize=tsfresh.defaults.CHUNKSIZE,
                                         n_processes=tsfresh.defaults.N_PROCESSES, show_warnings=tsfresh.defaults.SHOW_WARNINGS,
                                         disable_progressbar=tsfresh.defaults.DISABLE_PROGRESSBAR,
@@ -192,15 +192,15 @@ def _extract_features_parallel_per_kind(kind_to_df_map,
     :param column_value: The name for the column keeping the value itself.
     :type column_value: str
 
-    :param default_calculation_settings_mapping: mapping from feature calculator names to parameters. Only those names
+    :param default_para_map: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
            more information.
-    :type default_calculation_settings_mapping: dict
+    :type default_para_map: dict
 
-    :param kind_to_calculation_settings_mapping: mapping from kind names to objects of the same type as the ones for
-            default_calculation_settings_mapping. If you put a kind as a key here, the calculation_settings_mapping
-            object (which is the value), will be used instead of the default_calculation_settings_mapping.
-    :type kind_to_calculation_settings_mapping: dict
+    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
+            default_para_map. If you put a kind as a key here, the para_map
+            object (which is the value), will be used instead of the default_para_map.
+    :type kind_to_para_map: dict
 
     :param chunksize: The size of one chunk for the parallelisation
     :type chunksize: None or int
@@ -223,8 +223,8 @@ def _extract_features_parallel_per_kind(kind_to_df_map,
     partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
                                                            column_id=column_id,
                                                            column_value=column_value,
-                                                           default_calculation_settings_mapping=default_calculation_settings_mapping,
-                                                           kind_to_calculation_settings_mapping=kind_to_calculation_settings_mapping,
+                                                           default_para_map=default_para_map,
+                                                           kind_to_para_map=kind_to_para_map,
                                                            show_warnings=show_warnings)
     pool = Pool(n_processes)
 
@@ -250,8 +250,8 @@ def _extract_features_parallel_per_kind(kind_to_df_map,
 
 def _extract_features_parallel_per_sample(kind_to_df_map,
                                           column_id, column_value,
-                                          default_calculation_settings_mapping,
-                                          kind_to_calculation_settings_mapping=None,
+                                          default_para_map,
+                                          kind_to_para_map=None,
                                           chunksize=tsfresh.defaults.CHUNKSIZE,
                                           n_processes=tsfresh.defaults.N_PROCESSES, show_warnings=tsfresh.defaults.SHOW_WARNINGS,
                                           disable_progressbar=tsfresh.defaults.DISABLE_PROGRESSBAR,
@@ -272,15 +272,15 @@ def _extract_features_parallel_per_sample(kind_to_df_map,
     :param column_value: The name for the column keeping the value itself.
     :type column_value: str
 
-    :param default_calculation_settings_mapping: mapping from feature calculator names to parameters. Only those names
+    :param default_para_map: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
            more information.
-    :type default_calculation_settings_mapping: dict
+    :type default_para_map: dict
 
-    :param kind_to_calculation_settings_mapping: mapping from kind names to objects of the same type as the ones for
-            default_calculation_settings_mapping. If you put a kind as a key here, the calculation_settings_mapping
-            object (which is the value), will be used instead of the default_calculation_settings_mapping.
-    :type kind_to_calculation_settings_mapping: dict
+    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
+            default_para_map. If you put a kind as a key here, the para_map
+            object (which is the value), will be used instead of the default_para_map.
+    :type kind_to_para_map: dict
 
     :param chunksize: The size of one chunk for the parallelisation
     :type chunksize: None or int
@@ -303,8 +303,8 @@ def _extract_features_parallel_per_sample(kind_to_df_map,
     partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
                                                            column_id=column_id,
                                                            column_value=column_value,
-                                                           default_calculation_settings_mapping=default_calculation_settings_mapping,
-                                                           kind_to_calculation_settings_mapping=kind_to_calculation_settings_mapping,
+                                                           default_para_map=default_para_map,
+                                                           kind_to_para_map=kind_to_para_map,
                                                            show_warnings=show_warnings)
     pool = Pool(n_processes)
     total_number_of_expected_results = 0
@@ -376,8 +376,8 @@ def _calculate_best_chunksize(iterable_list, n_processes):
 
 
 def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, column_value,
-                                          default_calculation_settings_mapping,
-                                          kind_to_calculation_settings_mapping=None,
+                                          default_para_map,
+                                          kind_to_para_map=None,
                                           show_warnings=tsfresh.defaults.SHOW_WARNINGS):
     """
     Extract time series features for a given data frame based on the passed settings.
@@ -439,15 +439,15 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
     :param column_value: The name of the column with the values.
     :type column_value: str
 
-    :param default_calculation_settings_mapping: mapping from feature calculator names to parameters. Only those names
+    :param default_para_map: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
            more information.
-    :type default_calculation_settings_mapping: dict
+    :type default_para_map: dict
 
-    :param kind_to_calculation_settings_mapping: mapping from kind names to objects of the same type as the ones for
-            default_calculation_settings_mapping. If you put a kind as a key here, the calculation_settings_mapping
-            object (which is the value), will be used instead of the default_calculation_settings_mapping.
-    :type kind_to_calculation_settings_mapping: dict
+    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
+            default_para_map. If you put a kind as a key here, the para_map
+            object (which is the value), will be used instead of the default_para_map.
+    :type kind_to_para_map: dict
 
     :param show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
     :type show_warnings: bool
@@ -455,8 +455,8 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
     :return: A dataframe with the extracted features as the columns (prefixed with column_prefix) and as many
         rows as their are unique values in the id column.
     """
-    if kind_to_calculation_settings_mapping is None:
-        kind_to_calculation_settings_mapping = {}
+    if kind_to_para_map is None:
+        kind_to_para_map = {}
 
     column_prefix, dataframe = prefix_and_dataframe
     column_prefix = str(column_prefix)
@@ -465,10 +465,10 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
     dataframe[column_value] = dataframe[column_value].astype(np.float64)
 
     # If there are no special settings for this column_prefix, use the default ones.
-    if column_prefix in kind_to_calculation_settings_mapping:
-        calculation_settings_mapping = kind_to_calculation_settings_mapping[column_prefix]
+    if column_prefix in kind_to_para_map:
+        para_map = kind_to_para_map[column_prefix]
     else:
-        calculation_settings_mapping = default_calculation_settings_mapping
+        para_map = default_para_map
 
     with warnings.catch_warnings():
         if not show_warnings:
@@ -477,7 +477,7 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
             warnings.simplefilter("default")
 
         # Calculate the aggregation functions
-        column_name_to_aggregate_function = get_aggregate_functions(calculation_settings_mapping, column_prefix)
+        column_name_to_aggregate_function = get_aggregate_functions(para_map, column_prefix)
 
         if column_name_to_aggregate_function:
             extracted_features = dataframe.groupby(column_id)[column_value].aggregate(column_name_to_aggregate_function)
@@ -485,7 +485,7 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
             extracted_features = pd.DataFrame(index=dataframe[column_id].unique())
 
         # Calculate the apply functions
-        apply_functions = get_apply_functions(calculation_settings_mapping, column_prefix)
+        apply_functions = get_apply_functions(para_map, column_prefix)
 
         if apply_functions:
             list_of_extracted_feature_dataframes = [extracted_features]

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -24,8 +24,8 @@ from tsfresh.utilities import dataframe_functions, profiling
 _logger = logging.getLogger(__name__)
 
 
-def extract_features(timeseries_container, default_para_map=None,
-                     kind_to_para_map=None,
+def extract_features(timeseries_container, default_fc_parameters=None,
+                     kind_to_fc_parameters=None,
                      column_id=None, column_sort=None, column_kind=None, column_value=None,
                      parallelization=None, chunksize=tsfresh.defaults.CHUNKSIZE,
                      n_processes=tsfresh.defaults.N_PROCESSES, show_warnings=tsfresh.defaults.SHOW_WARNINGS,
@@ -66,15 +66,15 @@ def extract_features(timeseries_container, default_para_map=None,
             dictionary of pandas.DataFrames.
     :type timeseries_container: pandas.DataFrame or dict
 
-    :param default_para_map: mapping from feature calculator names to parameters. Only those names
+    :param default_fc_parameters: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
-    :type default_para_map: dict
+    :type default_fc_parameters: dict
 
-    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
-            default_para_map. If you put a kind as a key here, the para_map
-            object (which is the value), will be used instead of the default_para_map.
-    :type kind_to_para_map: dict
+    :param kind_to_fc_parameters: mapping from kind names to objects of the same type as the ones for
+            default_fc_parameters. If you put a kind as a key here, the fc_parameters
+            object (which is the value), will be used instead of the default_fc_parameters.
+    :type kind_to_fc_parameters: dict
 
     :param column_id: The name of the id column to group by.
     :type column_id: str
@@ -131,8 +131,8 @@ def extract_features(timeseries_container, default_para_map=None,
                                                                        column_kind, column_value)
 
     # Use the standard setting if the user did not supply ones himself.
-    if default_para_map is None:
-        default_para_map = ComprehensiveFCParameters()
+    if default_fc_parameters is None:
+        default_fc_parameters = ComprehensiveFCParameters()
 
     # Choose the parallelization according to a rule-of-thumb
     if parallelization is None:
@@ -153,8 +153,8 @@ def extract_features(timeseries_container, default_para_map=None,
         raise ValueError("Argument parallelization must be one of: 'per_kind', 'per_sample'")
 
     result = calculation_function(kind_to_df_map,
-                                  default_para_map=default_para_map,
-                                  kind_to_para_map=kind_to_para_map,
+                                  default_fc_parameters=default_fc_parameters,
+                                  kind_to_fc_parameters=kind_to_fc_parameters,
                                   column_id=column_id,
                                   column_value=column_value,
                                   chunksize=chunksize,
@@ -174,8 +174,8 @@ def extract_features(timeseries_container, default_para_map=None,
 
 def _extract_features_parallel_per_kind(kind_to_df_map,
                                         column_id, column_value,
-                                        default_para_map,
-                                        kind_to_para_map=None,
+                                        default_fc_parameters,
+                                        kind_to_fc_parameters=None,
                                         chunksize=tsfresh.defaults.CHUNKSIZE,
                                         n_processes=tsfresh.defaults.N_PROCESSES, show_warnings=tsfresh.defaults.SHOW_WARNINGS,
                                         disable_progressbar=tsfresh.defaults.DISABLE_PROGRESSBAR,
@@ -192,15 +192,15 @@ def _extract_features_parallel_per_kind(kind_to_df_map,
     :param column_value: The name for the column keeping the value itself.
     :type column_value: str
 
-    :param default_para_map: mapping from feature calculator names to parameters. Only those names
+    :param default_fc_parameters: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
-    :type default_para_map: dict
+    :type default_fc_parameters: dict
 
-    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
-            default_para_map. If you put a kind as a key here, the para_map
-            object (which is the value), will be used instead of the default_para_map.
-    :type kind_to_para_map: dict
+    :param kind_to_fc_parameters: mapping from kind names to objects of the same type as the ones for
+            default_fc_parameters. If you put a kind as a key here, the fc_parameters
+            object (which is the value), will be used instead of the default_fc_parameters.
+    :type kind_to_fc_parameters: dict
 
     :param chunksize: The size of one chunk for the parallelisation
     :type chunksize: None or int
@@ -223,8 +223,8 @@ def _extract_features_parallel_per_kind(kind_to_df_map,
     partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
                                                            column_id=column_id,
                                                            column_value=column_value,
-                                                           default_para_map=default_para_map,
-                                                           kind_to_para_map=kind_to_para_map,
+                                                           default_fc_parameters=default_fc_parameters,
+                                                           kind_to_fc_parameters=kind_to_fc_parameters,
                                                            show_warnings=show_warnings)
     pool = Pool(n_processes)
 
@@ -250,8 +250,8 @@ def _extract_features_parallel_per_kind(kind_to_df_map,
 
 def _extract_features_parallel_per_sample(kind_to_df_map,
                                           column_id, column_value,
-                                          default_para_map,
-                                          kind_to_para_map=None,
+                                          default_fc_parameters,
+                                          kind_to_fc_parameters=None,
                                           chunksize=tsfresh.defaults.CHUNKSIZE,
                                           n_processes=tsfresh.defaults.N_PROCESSES, show_warnings=tsfresh.defaults.SHOW_WARNINGS,
                                           disable_progressbar=tsfresh.defaults.DISABLE_PROGRESSBAR,
@@ -272,15 +272,15 @@ def _extract_features_parallel_per_sample(kind_to_df_map,
     :param column_value: The name for the column keeping the value itself.
     :type column_value: str
 
-    :param default_para_map: mapping from feature calculator names to parameters. Only those names
+    :param default_fc_parameters: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
-    :type default_para_map: dict
+    :type default_fc_parameters: dict
 
-    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
-            default_para_map. If you put a kind as a key here, the para_map
-            object (which is the value), will be used instead of the default_para_map.
-    :type kind_to_para_map: dict
+    :param kind_to_fc_parameters: mapping from kind names to objects of the same type as the ones for
+            default_fc_parameters. If you put a kind as a key here, the fc_parameters
+            object (which is the value), will be used instead of the default_fc_parameters.
+    :type kind_to_fc_parameters: dict
 
     :param chunksize: The size of one chunk for the parallelisation
     :type chunksize: None or int
@@ -303,8 +303,8 @@ def _extract_features_parallel_per_sample(kind_to_df_map,
     partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
                                                            column_id=column_id,
                                                            column_value=column_value,
-                                                           default_para_map=default_para_map,
-                                                           kind_to_para_map=kind_to_para_map,
+                                                           default_fc_parameters=default_fc_parameters,
+                                                           kind_to_fc_parameters=kind_to_fc_parameters,
                                                            show_warnings=show_warnings)
     pool = Pool(n_processes)
     total_number_of_expected_results = 0
@@ -376,8 +376,8 @@ def _calculate_best_chunksize(iterable_list, n_processes):
 
 
 def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, column_value,
-                                          default_para_map,
-                                          kind_to_para_map=None,
+                                          default_fc_parameters,
+                                          kind_to_fc_parameters=None,
                                           show_warnings=tsfresh.defaults.SHOW_WARNINGS):
     """
     Extract time series features for a given data frame based on the passed settings.
@@ -439,15 +439,15 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
     :param column_value: The name of the column with the values.
     :type column_value: str
 
-    :param default_para_map: mapping from feature calculator names to parameters. Only those names
+    :param default_fc_parameters: mapping from feature calculator names to parameters. Only those names
            which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
-    :type default_para_map: dict
+    :type default_fc_parameters: dict
 
-    :param kind_to_para_map: mapping from kind names to objects of the same type as the ones for
-            default_para_map. If you put a kind as a key here, the para_map
-            object (which is the value), will be used instead of the default_para_map.
-    :type kind_to_para_map: dict
+    :param kind_to_fc_parameters: mapping from kind names to objects of the same type as the ones for
+            default_fc_parameters. If you put a kind as a key here, the fc_parameters
+            object (which is the value), will be used instead of the default_fc_parameters.
+    :type kind_to_fc_parameters: dict
 
     :param show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
     :type show_warnings: bool
@@ -455,8 +455,8 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
     :return: A dataframe with the extracted features as the columns (prefixed with column_prefix) and as many
         rows as their are unique values in the id column.
     """
-    if kind_to_para_map is None:
-        kind_to_para_map = {}
+    if kind_to_fc_parameters is None:
+        kind_to_fc_parameters = {}
 
     column_prefix, dataframe = prefix_and_dataframe
     column_prefix = str(column_prefix)
@@ -465,10 +465,10 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
     dataframe[column_value] = dataframe[column_value].astype(np.float64)
 
     # If there are no special settings for this column_prefix, use the default ones.
-    if column_prefix in kind_to_para_map:
-        para_map = kind_to_para_map[column_prefix]
+    if column_prefix in kind_to_fc_parameters:
+        fc_parameters = kind_to_fc_parameters[column_prefix]
     else:
-        para_map = default_para_map
+        fc_parameters = default_fc_parameters
 
     with warnings.catch_warnings():
         if not show_warnings:
@@ -477,7 +477,7 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
             warnings.simplefilter("default")
 
         # Calculate the aggregation functions
-        column_name_to_aggregate_function = get_aggregate_functions(para_map, column_prefix)
+        column_name_to_aggregate_function = get_aggregate_functions(fc_parameters, column_prefix)
 
         if column_name_to_aggregate_function:
             extracted_features = dataframe.groupby(column_id)[column_value].aggregate(column_name_to_aggregate_function)
@@ -485,7 +485,7 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
             extracted_features = pd.DataFrame(index=dataframe[column_id].unique())
 
         # Calculate the apply functions
-        apply_functions = get_apply_functions(para_map, column_prefix)
+        apply_functions = get_apply_functions(fc_parameters, column_prefix)
 
         if apply_functions:
             list_of_extracted_feature_dataframes = [extracted_features]

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -17,7 +17,7 @@ import pandas as pd
 from builtins import str
 from six.moves.queue import Queue
 from tqdm import tqdm
-from tsfresh.feature_extraction.settings import FeatureExtractionSettings, get_aggregate_functions, get_apply_functions
+from tsfresh.feature_extraction.settings import ComprehensiveFCParameters, get_aggregate_functions, get_apply_functions
 import tsfresh.defaults
 from tsfresh.utilities import dataframe_functions, profiling
 
@@ -46,7 +46,7 @@ def extract_features(timeseries_container, default_para_map=None,
     In both cases a :class:`pandas.DataFrame` with the calculated features will be returned.
 
     For a list of all the calculated time series features, please see the
-    :class:`~tsfresh.feature_extraction.settings.FeatureExtractionSettings` class,
+    :class:`~tsfresh.feature_extraction.settings.ComprehensiveFCParameters` class,
     which is used to control which features with which parameters are calculated.
 
     For a detailed explanation of the different parameters and data formats please see :ref:`data-formats-label`.
@@ -67,7 +67,7 @@ def extract_features(timeseries_container, default_para_map=None,
     :type timeseries_container: pandas.DataFrame or dict
 
     :param default_para_map: mapping from feature calculator names to parameters. Only those names
-           which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
+           which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
     :type default_para_map: dict
 
@@ -132,7 +132,7 @@ def extract_features(timeseries_container, default_para_map=None,
 
     # Use the standard setting if the user did not supply ones himself.
     if default_para_map is None:
-        default_para_map = FeatureExtractionSettings()
+        default_para_map = ComprehensiveFCParameters()
 
     # Choose the parallelization according to a rule-of-thumb
     if parallelization is None:
@@ -193,7 +193,7 @@ def _extract_features_parallel_per_kind(kind_to_df_map,
     :type column_value: str
 
     :param default_para_map: mapping from feature calculator names to parameters. Only those names
-           which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
+           which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
     :type default_para_map: dict
 
@@ -273,7 +273,7 @@ def _extract_features_parallel_per_sample(kind_to_df_map,
     :type column_value: str
 
     :param default_para_map: mapping from feature calculator names to parameters. Only those names
-           which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
+           which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
     :type default_para_map: dict
 
@@ -421,7 +421,7 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
         +-------+------------------+------------------+-----+------------------+
 
     where N is the number of features that were calculated. Which features are calculated is controlled by the
-    passed settings instance (see :class:`~tsfresh.feature_extraction.settings.FeatureExtractionSettings` for a list of
+    passed settings instance (see :class:`~tsfresh.feature_extraction.settings.ComprehensiveFCParameters` for a list of
     all possible features to calculate).
 
     The parameter `dataframe` is not allowed to have any NaN value in it. It is possible to have different numbers
@@ -440,7 +440,7 @@ def _extract_features_for_one_time_series(prefix_and_dataframe, column_id, colum
     :type column_value: str
 
     :param default_para_map: mapping from feature calculator names to parameters. Only those names
-           which are keys in this dict will be calculated. See the class:`FeatureExtractionSettings` for
+           which are keys in this dict will be calculated. See the class:`ComprehensiveFCParameters` for
            more information.
     :type default_para_map: dict
 

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -19,14 +19,14 @@ from past.builtins import basestring
 from tsfresh.feature_extraction import feature_calculators
 
 
-def get_aggregate_functions(calculation_settings_mapping, column_prefix):
+def get_aggregate_functions(para_map, column_prefix):
     """
     Returns a dictionary with some of the column name mapped to the feature calculators that are
-    specified in the calculation_settings_mapping. This dictionary includes those calculators,
+    specified in the para_map. This dictionary includes those calculators,
     that can be used in a pandas group by command to extract all aggregate features at the same time.
 
-    :param calculation_settings_mapping: mapping from feature calculator names to settings.
-    :type calculation_settings_mapping: FeatureExtractionSettings or child class
+    :param para_map: mapping from feature calculator names to settings.
+    :type para_map: FeatureExtractionSettings or child class
 
     :param column_prefix: the prefix for all column names.
     :type column_prefix: basestring
@@ -37,7 +37,7 @@ def get_aggregate_functions(calculation_settings_mapping, column_prefix):
 
     aggregate_functions = {}
 
-    for name, param in calculation_settings_mapping.items():
+    for name, param in para_map.items():
 
         func = getattr(feature_calculators, name)
 
@@ -69,14 +69,14 @@ def get_aggregate_functions(calculation_settings_mapping, column_prefix):
     return aggregate_functions
 
 
-def get_apply_functions(calculation_settings_mapping, column_prefix):
+def get_apply_functions(para_map, column_prefix):
     """
     Returns a dictionary with some of the column name mapped to the feature calculators that are
-    specified in the calculation_settings_mapping. This dictionary includes those calculators,
+    specified in the para_map. This dictionary includes those calculators,
     that can *not* be used in a pandas group by command to extract all aggregate features at the same time.
 
-    :param calculation_settings_mapping: mapping from feature calculator names to settings.
-    :type calculation_settings_mapping: FeatureExtractionSettings or child class
+    :param para_map: mapping from feature calculator names to settings.
+    :type para_map: FeatureExtractionSettings or child class
 
     :param column_prefix: the prefix for all column names.
     :type column_prefix: basestring
@@ -87,7 +87,7 @@ def get_apply_functions(calculation_settings_mapping, column_prefix):
 
     apply_functions = []
 
-    for name, param in calculation_settings_mapping.items():
+    for name, param in para_map.items():
 
         func = getattr(feature_calculators, name)
 
@@ -108,7 +108,7 @@ def get_apply_functions(calculation_settings_mapping, column_prefix):
 
 def from_columns(columns):
     """
-    Creates a mapping from kind names to calculation_settings_mapping objects
+    Creates a mapping from kind names to para_map objects
     (which are itself mappings from feature calculators to settings)
     to extract only the features contained in the columns.
     To do so, for every feature name in columns this method
@@ -121,11 +121,11 @@ def from_columns(columns):
     :param columns: containing the feature names
     :type columns: list of str
 
-    :return: The kind_to_calculation_settings_mapping object ready to be used in the extract_features function.
+    :return: The kind_to_para_map object ready to be used in the extract_features function.
     :rtype: dict
     """
 
-    kind_to_calculation_settings_mapping = {}
+    kind_to_para_map = {}
 
     for col in columns:
 
@@ -142,8 +142,8 @@ def from_columns(columns):
         kind = parts[0]
         feature_name = parts[1]
 
-        if kind not in kind_to_calculation_settings_mapping:
-            kind_to_calculation_settings_mapping[kind] = {}
+        if kind not in kind_to_para_map:
+            kind_to_para_map[kind] = {}
 
         if not hasattr(feature_calculators, feature_name):
             raise ValueError("Unknown feature name {}".format(feature_name))
@@ -152,27 +152,27 @@ def from_columns(columns):
 
         if func.fctype == "aggregate":
 
-            kind_to_calculation_settings_mapping[kind][feature_name] = None
+            kind_to_para_map[kind][feature_name] = None
 
         elif func.fctype == "aggregate_with_parameters":
 
             config = _get_config_from_string(parts)
 
-            if feature_name in kind_to_calculation_settings_mapping[kind]:
-                kind_to_calculation_settings_mapping[kind][feature_name].append(config)
+            if feature_name in kind_to_para_map[kind]:
+                kind_to_para_map[kind][feature_name].append(config)
             else:
-                kind_to_calculation_settings_mapping[kind][feature_name] = [config]
+                kind_to_para_map[kind][feature_name] = [config]
 
         elif func.fctype == "apply":
 
             config = _get_config_from_string(parts)
 
-            if feature_name in kind_to_calculation_settings_mapping[kind]:
-                kind_to_calculation_settings_mapping[kind][feature_name].append(config)
+            if feature_name in kind_to_para_map[kind]:
+                kind_to_para_map[kind][feature_name].append(config)
             else:
-                kind_to_calculation_settings_mapping[kind][feature_name] = [config]
+                kind_to_para_map[kind][feature_name] = [config]
 
-    return kind_to_calculation_settings_mapping
+    return kind_to_para_map
 
 
 def _get_config_from_string(parts):
@@ -224,7 +224,7 @@ class FeatureExtractionSettings(dict):
         You can use the settings object with
 
         >>> from tsfresh.feature_extraction import extract_features, FeatureExtractionSettings
-        >>> extract_features(df, default_calculation_settings_mapping=FeatureExtractionSettings())
+        >>> extract_features(df, default_para_map=FeatureExtractionSettings())
 
         to extract all features (which is the default nevertheless) or you change the FeatureExtractionSettings
         object to other types (see below).
@@ -275,7 +275,7 @@ class MinimalFeatureExtractionSettings(FeatureExtractionSettings):
     You should use this object when calling the extract function, like so:
 
     >>> from tsfresh.feature_extraction import extract_features, MinimalFeatureExtractionSettings
-    >>> extract_features(df, default_calculation_settings_mapping=MinimalFeatureExtractionSettings())
+    >>> extract_features(df, default_para_map=MinimalFeatureExtractionSettings())
     """
     def __init__(self):
         FeatureExtractionSettings.__init__(self)
@@ -296,7 +296,7 @@ class ReasonableFeatureExtractionSettings(FeatureExtractionSettings):
     You should use this object when calling the extract function, like so:
 
     >>> from tsfresh.feature_extraction import extract_features, ReasonableFeatureExtractionSettings
-    >>> extract_features(df, default_calculation_settings_mapping=ReasonableFeatureExtractionSettings())
+    >>> extract_features(df, default_para_map=ReasonableFeatureExtractionSettings())
     """
 
     def __init__(self):

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -26,7 +26,7 @@ def get_aggregate_functions(para_map, column_prefix):
     that can be used in a pandas group by command to extract all aggregate features at the same time.
 
     :param para_map: mapping from feature calculator names to settings.
-    :type para_map: FeatureExtractionSettings or child class
+    :type para_map: ComprehensiveFCParameters or child class
 
     :param column_prefix: the prefix for all column names.
     :type column_prefix: basestring
@@ -76,7 +76,7 @@ def get_apply_functions(para_map, column_prefix):
     that can *not* be used in a pandas group by command to extract all aggregate features at the same time.
 
     :param para_map: mapping from feature calculator names to settings.
-    :type para_map: FeatureExtractionSettings or child class
+    :type para_map: ComprehensiveFCParameters or child class
 
     :param column_prefix: the prefix for all column names.
     :type column_prefix: basestring
@@ -208,10 +208,10 @@ def _get_config_from_string(parts):
 
 
 # todo: this classes' docstrings are not completely up-to-date
-class FeatureExtractionSettings(dict):
+class ComprehensiveFCParameters(dict):
     def __init__(self):
         """
-        Create a new FeatureExtractionSettings instance. You have to pass this instance to the
+        Create a new ComprehensiveFCParameters instance. You have to pass this instance to the
         extract_feature instance.
 
         It is basically a dictionary (and also based on one), which is a mapping from
@@ -223,10 +223,10 @@ class FeatureExtractionSettings(dict):
 
         You can use the settings object with
 
-        >>> from tsfresh.feature_extraction import extract_features, FeatureExtractionSettings
-        >>> extract_features(df, default_para_map=FeatureExtractionSettings())
+        >>> from tsfresh.feature_extraction import extract_features, ComprehensiveFCParameters
+        >>> extract_features(df, default_para_map=ComprehensiveFCParameters())
 
-        to extract all features (which is the default nevertheless) or you change the FeatureExtractionSettings
+        to extract all features (which is the default nevertheless) or you change the ComprehensiveFCParameters
         object to other types (see below).
         """
         name_to_param = {}
@@ -259,12 +259,12 @@ class FeatureExtractionSettings(dict):
             "approximate_entropy": [{"m": 2, "r": r} for r in [.1, .3, .5, .7, .9]]
         })
 
-        super(FeatureExtractionSettings, self).__init__(name_to_param)
+        super(ComprehensiveFCParameters, self).__init__(name_to_param)
 
 
-class MinimalFeatureExtractionSettings(FeatureExtractionSettings):
+class MinimalFCParameters(ComprehensiveFCParameters):
     """
-    This class is a child class of the FeatureExtractionSettings class
+    This class is a child class of the ComprehensiveFCParameters class
     and has the same functionality as its base class. The only difference is,
     that most of the feature calculators are disabled and only a small
     subset of calculators will be calculated at all. Those are donated by an attribute called "minimal".
@@ -274,20 +274,20 @@ class MinimalFeatureExtractionSettings(FeatureExtractionSettings):
 
     You should use this object when calling the extract function, like so:
 
-    >>> from tsfresh.feature_extraction import extract_features, MinimalFeatureExtractionSettings
-    >>> extract_features(df, default_para_map=MinimalFeatureExtractionSettings())
+    >>> from tsfresh.feature_extraction import extract_features, MinimalFCParameters
+    >>> extract_features(df, default_para_map=MinimalFCParameters())
     """
     def __init__(self):
-        FeatureExtractionSettings.__init__(self)
+        ComprehensiveFCParameters.__init__(self)
 
         for fname, f in feature_calculators.__dict__.items():
             if fname in self and (not hasattr(f, "minimal") or not getattr(f, "minimal")):
                 del self[fname]
 
 
-class ReasonableFeatureExtractionSettings(FeatureExtractionSettings):
+class EfficientFCParameters(ComprehensiveFCParameters):
     """
-    This class is a child class of the FeatureExtractionSettings class
+    This class is a child class of the ComprehensiveFCParameters class
     and has the same functionality as its base class.
 
     The only difference is, that the features with high computational costs are not calculated. Those are denoted by
@@ -295,12 +295,12 @@ class ReasonableFeatureExtractionSettings(FeatureExtractionSettings):
 
     You should use this object when calling the extract function, like so:
 
-    >>> from tsfresh.feature_extraction import extract_features, ReasonableFeatureExtractionSettings
-    >>> extract_features(df, default_para_map=ReasonableFeatureExtractionSettings())
+    >>> from tsfresh.feature_extraction import extract_features, EfficientFCParameters
+    >>> extract_features(df, default_para_map=EfficientFCParameters())
     """
 
     def __init__(self):
-        FeatureExtractionSettings.__init__(self)
+        ComprehensiveFCParameters.__init__(self)
 
         # drop all features with high computational costs
         for fname, f in feature_calculators.__dict__.items():

--- a/tsfresh/transformers/feature_augmenter.py
+++ b/tsfresh/transformers/feature_augmenter.py
@@ -55,8 +55,8 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
     For a description what the parameters column_id, column_sort, column_kind and column_value mean, please see
     :mod:`~tsfresh.feature_extraction.extraction`.
     """
-    def __init__(self, default_calculation_settings_mapping=None,
-                 kind_to_calculation_settings_mapping=None, column_id=None, column_sort=None,
+    def __init__(self, default_para_map=None,
+                 kind_to_para_map=None, column_id=None, column_sort=None,
                  column_kind=None, column_value=None, timeseries_container=None,
                  parallelization=None, chunksize=tsfresh.defaults.CHUNKSIZE,
                  n_processes=tsfresh.defaults.N_PROCESSES, show_warnings=tsfresh.defaults.SHOW_WARNINGS,
@@ -114,8 +114,8 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
         :param profiling_filename: Where to save the profiling results.
         :type profiling_filename: basestring
         """
-        self.default_calculation_settings_mapping = default_calculation_settings_mapping
-        self.kind_to_calculation_settings_mapping = kind_to_calculation_settings_mapping
+        self.default_para_map = default_para_map
+        self.kind_to_para_map = kind_to_para_map
 
         self.column_id = column_id
         self.column_sort = column_sort
@@ -187,8 +187,8 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
         timeseries_container_X = restrict_input_to_index(self.timeseries_container, self.column_id, X.index)
 
         extracted_features = extract_features(timeseries_container_X,
-                                              default_calculation_settings_mapping=self.default_calculation_settings_mapping,
-                                              kind_to_calculation_settings_mapping=self.kind_to_calculation_settings_mapping,
+                                              default_para_map=self.default_para_map,
+                                              kind_to_para_map=self.kind_to_para_map,
                                               column_id=self.column_id, column_sort=self.column_sort,
                                               column_kind=self.column_kind, column_value=self.column_value,
                                               parallelization=self.parallelization, chunksize=self.chunksize,

--- a/tsfresh/transformers/feature_augmenter.py
+++ b/tsfresh/transformers/feature_augmenter.py
@@ -45,7 +45,7 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
     >>> df_with_time_series_features = augmenter.transform(df)
 
     The settings for the feature calculation can be controlled with the settings object. If you pass ``None``, the default
-    settings are used. Please refer to :class:`~tsfresh.feature_extraction.settings.FeatureExtractionSettings` for
+    settings are used. Please refer to :class:`~tsfresh.feature_extraction.settings.ComprehensiveFCParameters` for
     more information.
 
     This estimator does not select the relevant features, but calculates and adds all of them to the DataFrame. See the
@@ -70,7 +70,7 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
         Create a new FeatureAugmenter instance.
 
         :param settings: The extraction settings to use. Leave empty to use the default ones.
-        :type settings: tsfresh.feature_extraction.settings.FeatureExtractionSettings
+        :type settings: tsfresh.feature_extraction.settings.ComprehensiveFCParameters
 
         :param column_id: The column with the id. See :mod:`~tsfresh.feature_extraction.extraction`.
         :type column_id: basestring

--- a/tsfresh/transformers/feature_augmenter.py
+++ b/tsfresh/transformers/feature_augmenter.py
@@ -55,8 +55,8 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
     For a description what the parameters column_id, column_sort, column_kind and column_value mean, please see
     :mod:`~tsfresh.feature_extraction.extraction`.
     """
-    def __init__(self, default_para_map=None,
-                 kind_to_para_map=None, column_id=None, column_sort=None,
+    def __init__(self, default_fc_parameters=None,
+                 kind_to_fc_parameters=None, column_id=None, column_sort=None,
                  column_kind=None, column_value=None, timeseries_container=None,
                  parallelization=None, chunksize=tsfresh.defaults.CHUNKSIZE,
                  n_processes=tsfresh.defaults.N_PROCESSES, show_warnings=tsfresh.defaults.SHOW_WARNINGS,
@@ -114,8 +114,8 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
         :param profiling_filename: Where to save the profiling results.
         :type profiling_filename: basestring
         """
-        self.default_para_map = default_para_map
-        self.kind_to_para_map = kind_to_para_map
+        self.default_fc_parameters = default_fc_parameters
+        self.kind_to_fc_parameters = kind_to_fc_parameters
 
         self.column_id = column_id
         self.column_sort = column_sort
@@ -187,8 +187,8 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
         timeseries_container_X = restrict_input_to_index(self.timeseries_container, self.column_id, X.index)
 
         extracted_features = extract_features(timeseries_container_X,
-                                              default_para_map=self.default_para_map,
-                                              kind_to_para_map=self.kind_to_para_map,
+                                              default_fc_parameters=self.default_fc_parameters,
+                                              kind_to_fc_parameters=self.kind_to_fc_parameters,
                                               column_id=self.column_id, column_sort=self.column_sort,
                                               column_kind=self.column_kind, column_value=self.column_value,
                                               parallelization=self.parallelization, chunksize=self.chunksize,

--- a/tsfresh/transformers/relevant_feature_augmenter.py
+++ b/tsfresh/transformers/relevant_feature_augmenter.py
@@ -83,8 +83,8 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
 
     def __init__(self,
                  filter_only_tsfresh_features=True,
-                 default_para_map=None,
-                 kind_to_para_map=None,
+                 default_fc_parameters=None,
+                 kind_to_fc_parameters=None,
                  column_id=None, column_sort=None, column_kind=None, column_value=None,
                  timeseries_container=None,
                  parallelization=defaults.PARALLELISATION, chunksize=defaults.CHUNKSIZE,
@@ -178,8 +178,8 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
 
         self.feature_extractor = FeatureAugmenter(column_id=column_id, column_sort=column_sort, column_kind=column_kind,
                                                   column_value=column_value,
-                                                  default_para_map=default_para_map,
-                                                  kind_to_para_map=kind_to_para_map,
+                                                  default_fc_parameters=default_fc_parameters,
+                                                  kind_to_fc_parameters=kind_to_fc_parameters,
                                                   parallelization=parallelization, chunksize=chunksize,
                                                   n_processes=n_processes, show_warnings=show_warnings,
                                                   disable_progressbar=disable_progressbar,
@@ -289,8 +289,8 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         impute_function = partial(impute_dataframe_range, col_to_max=self.col_to_max,
                                   col_to_min=self.col_to_min, col_to_median=self.col_to_median)
 
-        relevant_feature_extractor = FeatureAugmenter(kind_to_para_map=relevant_extraction_settings,
-                                                      default_para_map={},
+        relevant_feature_extractor = FeatureAugmenter(kind_to_fc_parameters=relevant_extraction_settings,
+                                                      default_fc_parameters={},
                                                       column_id=self.feature_extractor.column_id,
                                                       column_sort=self.feature_extractor.column_sort,
                                                       column_kind=self.feature_extractor.column_kind,

--- a/tsfresh/transformers/relevant_feature_augmenter.py
+++ b/tsfresh/transformers/relevant_feature_augmenter.py
@@ -83,8 +83,8 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
 
     def __init__(self,
                  filter_only_tsfresh_features=True,
-                 default_calculation_settings_mapping=None,
-                 kind_to_calculation_settings_mapping=None,
+                 default_para_map=None,
+                 kind_to_para_map=None,
                  column_id=None, column_sort=None, column_kind=None, column_value=None,
                  timeseries_container=None,
                  parallelization=defaults.PARALLELISATION, chunksize=defaults.CHUNKSIZE,
@@ -178,8 +178,8 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
 
         self.feature_extractor = FeatureAugmenter(column_id=column_id, column_sort=column_sort, column_kind=column_kind,
                                                   column_value=column_value,
-                                                  default_calculation_settings_mapping=default_calculation_settings_mapping,
-                                                  kind_to_calculation_settings_mapping=kind_to_calculation_settings_mapping,
+                                                  default_para_map=default_para_map,
+                                                  kind_to_para_map=kind_to_para_map,
                                                   parallelization=parallelization, chunksize=chunksize,
                                                   n_processes=n_processes, show_warnings=show_warnings,
                                                   disable_progressbar=disable_progressbar,
@@ -289,8 +289,8 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         impute_function = partial(impute_dataframe_range, col_to_max=self.col_to_max,
                                   col_to_min=self.col_to_min, col_to_median=self.col_to_median)
 
-        relevant_feature_extractor = FeatureAugmenter(kind_to_calculation_settings_mapping=relevant_extraction_settings,
-                                                      default_calculation_settings_mapping={},
+        relevant_feature_extractor = FeatureAugmenter(kind_to_para_map=relevant_extraction_settings,
+                                                      default_para_map={},
                                                       column_id=self.feature_extractor.column_id,
                                                       column_sort=self.feature_extractor.column_sort,
                                                       column_kind=self.feature_extractor.column_kind,

--- a/tsfresh/transformers/relevant_feature_augmenter.py
+++ b/tsfresh/transformers/relevant_feature_augmenter.py
@@ -32,7 +32,7 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
     This estimator is a wrapper around most of the functionality in the tsfresh package. For more information on the
     subtasks, please refer to the single modules and functions, which are:
 
-    * Settings for the feature extraction: :class:`~tsfresh.feature_extraction.settings.FeatureExtractionSettings`
+    * Settings for the feature extraction: :class:`~tsfresh.feature_extraction.settings.ComprehensiveFCParameters`
     * Feature extraction method: :func:`~tsfresh.feature_extraction.extraction.extract_features`
     * Extracted features: :mod:`~tsfresh.feature_extraction.feature_calculators`
     * Feature selection: :func:`~tsfresh.feature_selection.feature_selector.check_fs_sig_bh`
@@ -103,7 +103,7 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         Create a new RelevantFeatureAugmenter instance.
 
         :param settings: The extraction settings to use. Leave empty to use the default ones.
-        :type settings: tsfresh.feature_extraction.settings.FeatureExtractionSettings
+        :type settings: tsfresh.feature_extraction.settings.ExtendedFCParameters
 
         :param filter_only_tsfresh_features: Whether to touch the manually-created features during feature selection or
                                              not.
@@ -111,7 +111,7 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         :param feature_selection_settings: The feature selection settings.
         :type feature_selection_settings: tsfresh.feature_selection.settings.FeatureSelectionSettings
         :param feature_extraction_settings: The feature extraction settings.
-        :type feature_selection_settings: tsfresh.feature_extraction.settings.FeatureExtractionSettings
+        :type feature_selection_settings: tsfresh.feature_extraction.settings.ComprehensiveFCParameters
         :param column_id: The column with the id. See :mod:`~tsfresh.feature_extraction.extraction`.
         :type column_id: basestring
         :param column_sort: The column with the sort data. See :mod:`~tsfresh.feature_extraction.extraction`.


### PR DESCRIPTION
I renamed `calculation_settings_mapping` to `para_map`. 

I do not like the long name, which result in a java like beasts such as  `default_calculation_settings_mapping` or `kind_to_calculation_settings_mapping`.

We should have a catchy, short (<10 character) name for the extraction settings. We are breaking our public API, so now is the time to change it.