### PR TITLE
Fix for issue 147 - no handler warning

### DIFF
--- a/tsfresh/__init__.py
+++ b/tsfresh/__init__.py
@@ -18,6 +18,18 @@ except:
     __version__ = 'unknown'
 
 
+# Set default logging handler to avoid "No handler found" warnings.
+import logging
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+logging.getLogger(__name__).addHandler(NullHandler())
+
+
 from tsfresh.convenience.relevant_extraction import extract_relevant_features
 from tsfresh.feature_extraction import extract_features
 from tsfresh.feature_selection import select_features

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -83,6 +83,9 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
     :return: The (maybe imputed) DataFrame containing extracted features.
     :rtype: pandas.DataFrame
     """
+    import logging
+    logging.basicConfig()
+    
     # Always use the standardized way of storing the data.
     # See the function normalize_input_to_internal_representation for more information.
     kind_to_df_map, column_id, column_value = \


### PR DESCRIPTION
New pull request for issue #147. 
 The user can then specify the log level by something like: 
```import logging```
```logging.basicConfig(level=logging.INFO)```