### PR TITLE
moved imputing out of the loop

### DIFF
--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -241,12 +241,11 @@ def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, c
             map_result = results_fifo.get()
             dfs_kind = iterable_with_tqdm_update(map_result, progress_bar)
             df_tmp = pd.concat(dfs_kind, axis=0).astype(np.float64)
-
-            # Impute the result if requested
-            if settings.IMPUTE is not None:
-                settings.IMPUTE(df_tmp)
-
             result = pd.concat([result, df_tmp], axis=1).astype(np.float64)
+
+    # Impute the result if requested
+    if settings.IMPUTE is not None:
+        settings.IMPUTE(result)
 
     pool.join()
     return result


### PR DESCRIPTION
This would be the easiest solution to move the imputing out of the loops where the id chunks are aggregated.

What do you think? 