### PR TITLE
Make extraction faster

### DIFF
--- a/tests/examples/test_robot_execution_failures.py
+++ b/tests/examples/test_robot_execution_failures.py
@@ -3,18 +3,25 @@
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
 from unittest import TestCase
+
+from tsfresh import extract_features
 from tsfresh.examples.robot_execution_failures import load_robot_execution_failures, download_robot_execution_failures
 from pandas import DataFrame, Series
 import six
+
 
 class RobotExecutionFailuresTestCase(TestCase):
     def setUp(self):
         download_robot_execution_failures()
         self.X, self.y = load_robot_execution_failures()
 
-
     def test_characteristics_downloaded_robot_execution_failures(self):
         self.assertEqual(len(self.X), 1320)
         self.assertIsInstance(self.X, DataFrame)
         self.assertIsInstance(self.y, Series)
         six.assertCountEqual(self, ['id', 'time', 'a', 'b', 'c', 'd', 'e', 'f'], list(self.X.columns))
+
+if __name__ == '__main__':
+    timeseries, y = load_robot_execution_failures()
+    extracted_features = extract_features(timeseries[timeseries.id < 20], column_id="id", column_sort="time",
+                                          parallelization="no_parallelization")

--- a/tests/feature_extraction/test_extraction.py
+++ b/tests/feature_extraction/test_extraction.py
@@ -164,12 +164,18 @@ class ExtractionTestCase(DataTestCase):
         features_per_sample = extract_features(df, self.settings, "id", "sort", "kind", "val",
                                                parallelization='per_sample')
         features_per_kind = extract_features(df, self.settings, "id", "sort", "kind", "val",
-                                               parallelization='per_kind')
+                                             parallelization='per_kind')
+        features_serial = extract_features(df, self.settings, "id", "sort", "kind", "val",
+                                           parallelization='no_parallelization')
 
         six.assertCountEqual(self, features_per_sample.columns, features_per_kind.columns)
+        six.assertCountEqual(self, features_per_sample.columns, features_serial.columns)
 
         for col in features_per_sample.columns:
             self.assertIsNone(np.testing.assert_array_almost_equal(features_per_sample[col],
+                                                                   features_per_kind[col]))
+        for col in features_per_sample.columns:
+            self.assertIsNone(np.testing.assert_array_almost_equal(features_serial[col],
                                                                    features_per_kind[col]))
 
 

--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -29,10 +29,20 @@ class FeatureCalculationTestCase(TestCase):
         self.assertTrue(f(np.array(input_to_f), *args, **kwargs), msg="Not true for numpy.arrays")
         self.assertTrue(f(pd.Series(input_to_f), *args, **kwargs), msg="Not true for pandas.Series")
 
+    def assertAllTrueOnAllArrayTypes(self, f, input_to_f, *args, **kwargs):
+        self.assertTrue(all(f(input_to_f, *args, **kwargs)), msg="Not true for lists")
+        self.assertTrue(all(f(np.array(input_to_f), *args, **kwargs)), msg="Not true for numpy.arrays")
+        self.assertTrue(all(f(pd.Series(input_to_f), *args, **kwargs)), msg="Not true for pandas.Series")
+
     def assertFalseOnAllArrayTypes(self, f, input_to_f, *args, **kwargs):
         self.assertFalse(f(input_to_f, *args, **kwargs), msg="Not false for lists")
         self.assertFalse(f(np.array(input_to_f), *args, **kwargs), msg="Not false for numpy.arrays")
         self.assertFalse(f(pd.Series(input_to_f), *args, **kwargs), msg="Not false for pandas.Series")
+
+    def assertAllFalseOnAllArrayTypes(self, f, input_to_f, *args, **kwargs):
+        self.assertFalse(any(f(input_to_f, *args, **kwargs)), msg="Not false for lists")
+        self.assertFalse(any(f(np.array(input_to_f), *args, **kwargs)), msg="Not false for numpy.arrays")
+        self.assertFalse(any(f(pd.Series(input_to_f), *args, **kwargs)), msg="Not false for pandas.Series")
 
     def assertAlmostEqualOnAllArrayTypes(self, f, input_t_f, result, *args, **kwargs):
         self.assertAlmostEqual(f(input_t_f, *args, **kwargs), result,
@@ -86,12 +96,12 @@ class FeatureCalculationTestCase(TestCase):
         self.assertFalseOnAllArrayTypes(large_standard_deviation, [-1, -1, 1, 1], r=0.5)
 
     def test_symmetry_looking(self):
-        self.assertTrueOnAllArrayTypes(symmetry_looking, [-1, -1, 1, 1], r=0.05)
-        self.assertTrueOnAllArrayTypes(symmetry_looking, [-1, -1, 1, 1], r=0.75)
-        self.assertFalseOnAllArrayTypes(symmetry_looking, [-1, -1, 1, 1], r=0)
-        self.assertFalseOnAllArrayTypes(symmetry_looking, [-1, -1, -1, -1, 1], r=0.05)
-        self.assertTrueOnAllArrayTypes(symmetry_looking, [-2, -2, -2, -1, -1, -1], r=0.05)
-        self.assertTrueOnAllArrayTypes(symmetry_looking, [-0.9, -0.900001], r=0.05)
+        self.assertAllTrueOnAllArrayTypes(symmetry_looking, [-1, -1, 1, 1],
+                                          "c", [dict(r=0.05), dict(r=0.75)])
+        self.assertAllFalseOnAllArrayTypes(symmetry_looking, [-1, -1, 1, 1], "c", [dict(r=0)])
+        self.assertAllFalseOnAllArrayTypes(symmetry_looking, [-1, -1, -1, -1, 1], "c", [dict(r=0.05)])
+        self.assertAllTrueOnAllArrayTypes(symmetry_looking, [-2, -2, -2, -1, -1, -1], "c", [dict(r=0.05)])
+        self.assertAllTrueOnAllArrayTypes(symmetry_looking, [-0.9, -0.900001], "c", [dict(r=0.05)])
 
     def test_has_duplicate_max(self):
         self.assertTrueOnAllArrayTypes(has_duplicate_max, [2.1, 0, 0, 2.1, 1.1])

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -120,7 +120,8 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
         result = _extract_features_parallel_per_sample(kind_to_df_map, feature_extraction_settings,
                                                        column_id, column_value)
     elif parallelization == 'no_parallelization':
-        result = _extract_features_serial(kind_to_df_map, feature_extraction_settings, column_id, column_value)
+        result = _extract_features_parallel_per_kind(kind_to_df_map, feature_extraction_settings,
+                                                     column_id, column_value, serial=True)
     else:
         raise ValueError("Argument parallelization must be one of: 'per_kind', 'per_sample'")
 
@@ -132,7 +133,7 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
     return result
 
 
-def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, column_value):
+def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, column_value, serial=False):
     """
     Parallelize the feature extraction per kind.
 
@@ -147,6 +148,9 @@ def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, col
     :param settings: settings object that controls which features are calculated
     :type settings: tsfresh.feature_extraction.settings.FeatureExtractionSettings
 
+    :param serial: Do not parallelize the extraction. This can be handy if (1) you want to debug something
+       (2) you want to profile something or (3) your environment does not support multiprocessing
+
     :return: The (maybe imputed) DataFrame containing extracted features.
     :rtype: pandas.DataFrame
     """
@@ -159,8 +163,14 @@ def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, col
     chunksize = helper_functions.calculate_best_chunksize(kind_to_df_map, settings)
 
     total_number_of_expected_results = len(kind_to_df_map)
-    extracted_features = tqdm(pool.imap_unordered(partial_extract_features_for_one_time_series, kind_to_df_map.items(),
-                                                  chunksize=chunksize), total=total_number_of_expected_results,
+
+    if serial:
+        map_function = map
+    else:
+        map_function = partial(pool.imap_unordered, chunksize=chunksize)
+
+    extracted_features = tqdm(map_function(partial_extract_features_for_one_time_series, kind_to_df_map.items()),
+                              total=total_number_of_expected_results,
                               desc="Feature Extraction", disable=settings.disable_progressbar)
 
     pool.close()
@@ -174,45 +184,6 @@ def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, col
 
     pool.join()
     return result
-
-
-def _extract_features_serial(kind_to_df_map, settings, column_id, column_value):
-    """
-    Feature extraction without parallelization.
-
-    :param kind_to_df_map: The time series to compute the features for in our internal format
-    :type kind_to_df_map: dict of pandas.DataFrame
-
-    :param column_id: The name of the id column to group by.
-    :type column_id: str
-    :param column_value: The name for the column keeping the value itself.
-    :type column_value: str
-
-    :param settings: settings object that controls which features are calculated
-    :type settings: tsfresh.feature_extraction.settings.FeatureExtractionSettings
-
-    :return: The (maybe imputed) DataFrame containing extracted features.
-    :rtype: pandas.DataFrame
-    """
-    partial_extract_features_for_one_time_series = partial(_extract_features_for_one_time_series,
-                                                           column_id=column_id,
-                                                           column_value=column_value,
-                                                           settings=settings)
-
-    total_number_of_expected_results = len(kind_to_df_map)
-    extracted_features = tqdm(map(partial_extract_features_for_one_time_series, kind_to_df_map.items()),
-                              total=total_number_of_expected_results,
-                              desc="Feature Extraction", disable=settings.disable_progressbar)
-
-    # Concatenate all partial results
-    result = pd.concat(extracted_features, axis=1, join='outer').astype(np.float64)
-
-    # Impute the result if requested
-    if settings.IMPUTE is not None:
-        settings.IMPUTE(result)
-
-    return result
-
 
 def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, column_value):
     """

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -114,14 +114,14 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
 
     # Calculate the result
     if parallelization == 'per_kind':
-        result = _extract_features_parallel_per_kind(kind_to_df_map, feature_extraction_settings,
-                                                     column_id, column_value)
+        result = _extract_features_per_kind(kind_to_df_map, feature_extraction_settings,
+                                            column_id, column_value)
     elif parallelization == 'per_sample':
         result = _extract_features_parallel_per_sample(kind_to_df_map, feature_extraction_settings,
                                                        column_id, column_value)
     elif parallelization == 'no_parallelization':
-        result = _extract_features_parallel_per_kind(kind_to_df_map, feature_extraction_settings,
-                                                     column_id, column_value, serial=True)
+        result = _extract_features_per_kind(kind_to_df_map, feature_extraction_settings,
+                                            column_id, column_value, serial=True)
     else:
         raise ValueError("Argument parallelization must be one of: 'per_kind', 'per_sample'")
 
@@ -133,7 +133,7 @@ def extract_features(timeseries_container, feature_extraction_settings=None,
     return result
 
 
-def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, column_value, serial=False):
+def _extract_features_per_kind(kind_to_df_map, settings, column_id, column_value, serial=False):
     """
     Parallelize the feature extraction per kind.
 
@@ -184,6 +184,7 @@ def _extract_features_parallel_per_kind(kind_to_df_map, settings, column_id, col
 
     pool.join()
     return result
+
 
 def _extract_features_parallel_per_sample(kind_to_df_map, settings, column_id, column_value):
     """

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -126,6 +126,7 @@ def large_standard_deviation(x, r):
     :return: the value of this feature
     :return type: bool
     """
+    x = np.asarray(x)
     return np.std(x) > (r * (max(x) - min(x)))
 
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -795,20 +795,24 @@ def index_mass_quantile(x, c, param):
     :return: the different feature values
     :return type: pandas.Series
     """
-    s = sum(np.abs(x))
-    res = pd.Series()
 
-    x = pd.Series(x)
+    x = np.asarray(x)
+    abs_x = np.abs(x)
+    s = sum(abs_x)
 
-    if s == 0: # all values in x are zero or it has length 0
+    res = {}
+
+    if s == 0:
+        # all values in x are zero or it has length 0
         for config in param:
             res["{}__index_mass_quantile__q_{}".format(c, config["q"])] = np.NaN
-    else: # at least one value is not zero
-        mass_centralized = (np.cumsum(np.abs(x)) * 1.0 / s).values
+    else:
+        # at least one value is not zero
+        mass_centralized = np.cumsum(abs_x) / s
         for config in param:
             res["{}__index_mass_quantile__q_{}".format(c, config["q"])] = \
                 (np.argmax(mass_centralized >= config["q"])+1)/len(x)
-    return res
+    return pd.Series(res)
 
 
 @set_property("fctype", "aggregate_with_parameters")

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -762,11 +762,20 @@ def number_peaks(x, n):
     :return: the value of this feature
     :return type: float
     """
-    res = list()
+    x = np.asarray(x)
+    x_reduced = x[n:-n]
+
+    res = None
     for i in range(1, n + 1):
-        res += [(x > np.roll(x, i))[n:-n]]
-        res += [(x > np.roll(x, -i))[n:-n]]
-    return sum(reduce(lambda a, b: a & b, res))
+        result_first = (x_reduced > np.roll(x, i)[n:-n])
+
+        if res is None:
+            res = result_first
+        else:
+            res &= result_first
+
+        res &= (x_reduced > np.roll(x, -i)[n:-n])
+    return sum(res)
 
 
 @set_property("fctype", "apply")

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -146,6 +146,7 @@ def symmetry_looking(x, r):
     :return: the value of this feature
     :return type: bool
     """
+    x = np.asarray(x)
     return abs(np.mean(x) - np.median(x)) < (r * (max(x) - min(x)))
 
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -960,20 +960,20 @@ def ar_coefficient(x, c, param):
 
         column_name = "{}__ar_coefficient__k_{}__coeff_{}".format(c, k, p)
 
-        try:
-            if k not in calculated_ar_params:
+        if k not in calculated_ar_params:
+            try:
                 calculated_ar_params[k] = calculated_AR.fit(maxlag=k, solver="mle").params
+            except (LinAlgError, ValueError):
+                calculated_ar_params[k] = [np.NaN]*k
 
-            mod = calculated_ar_params[k]
+        mod = calculated_ar_params[k]
 
-            if p <= k:
-                try:
-                    res[column_name] = mod[p]
-                except IndexError:
-                    res[column_name] = 0
-            else:
-                res[column_name] = np.NaN
-        except (LinAlgError, ValueError):
+        if p <= k:
+            try:
+                res[column_name] = mod[p]
+            except IndexError:
+                res[column_name] = 0
+        else:
             res[column_name] = np.NaN
 
     return pd.Series(res)

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -130,9 +130,9 @@ def large_standard_deviation(x, r):
     return np.std(x) > (r * (max(x) - min(x)))
 
 
-@set_property("fctype", "aggregate_with_parameters")
+@set_property("fctype", "apply")
 @not_apply_to_raw_numbers
-def symmetry_looking(x, r):
+def symmetry_looking(x, c, param):
     """
     Boolean variable denoting if the distribution of x *looks symmetric*. This is the case if
 
@@ -148,8 +148,10 @@ def symmetry_looking(x, r):
     :return type: bool
     """
     x = np.asarray(x)
-    return abs(np.mean(x) - np.median(x)) < (r * (max(x) - min(x)))
-
+    mean_median_difference = abs(np.mean(x) - np.median(x))
+    max_min_difference = max(x) - min(x)
+    return pd.Series({"{}__symmetry_looking__r_{}".format(c, r["r"]):
+                          mean_median_difference < (r["r"] * max_min_difference) for r in param})
 
 @set_property("fctype", "aggregate")
 @not_apply_to_raw_numbers


### PR DESCRIPTION
This one was some major work, so let me describe everything in detail:
I have done some profiling to increase the runtime performance of the feature extraction. 

I have done this using two tools (as reference for later): cProfile + pyprof2calltree for vizualisation and kernprof (from line_profiling), e.g. with

    python -m cProfile -o prof.out tests/examples/test_robot_execution_failures.py
    pyprof2calltree -i prof.out -k
    kernprof -l -v tests/examples/test_robot_execution_failures.py

Everything was done on our default robots failures dataset (I know that this may not be the perfect example for out usage, but I need to use something that is standardized).

After identifying the main runtime issues, I have refactored them step by step. I have made sure, that the results stayed the same during all steps using the full robots dataset and our unit tests.

Here are the results:

| What | Before | After |
| ------- | --------- | ------- |
| extraction on full robot set (without parallelization) | 39.51s | 20.68s ( - 48% !!!) |
| run all unittest | 41.91s | 38.73s | 

Parallelisation was turned off for the first measurement, to not rely on kernel process management etc.

The changes to the functions were in detail (all in s for the first 20 ids of the robot set):

| Name | Before | After |
| ---- | ---- | ---- |
| large_standard_dev | 0.33 | 0.076 |
| symmetry_looking | 0.758 | 0.046 |
| number_peaks | 3.901 | 0.160 |
| index_mass_quantile | 0.926 | 0.039 |
| cwt_coeff | 1.813 | 0.129 |
| ar_coeff | 0.626 | 0.1629 |

After that, we only have 4 functions left, that have "large" performance issues:
* augmented_dicker_fuller 14 %
* mean_abs_change_qunatiles 25 %
* autocorrelation 14 %
* quantile 6 %

The percentage numbers are the percentage they use up during the full extraction function.

TLDR: I increased the runtime by approx 50% on our test dataset while remaining the content of the calculations.