### PR TITLE
Fix the trunction bug for fft_coefficients

### DIFF
--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -319,10 +319,20 @@ class FeatureCalculationTestCase(TestCase):
                           'coeff_0__attr_"imag"', 'coeff_1__attr_"imag"', 'coeff_2__attr_"imag"']
 
         res = pd.Series(dict(fft_coefficient(x, param)))
-        print(res)
         six.assertCountEqual(self, list(res.index), expected_index)
-        self.assertAlmostEqual(res['coeff_0__attr_"imag"'], 0, places=1)
-        self.assertAlmostEqual(res['coeff_0__attr_"real"'], sum(x), places=1)
+        self.assertAlmostEqual(res['coeff_0__attr_"imag"'], 0, places=6)
+        self.assertAlmostEqual(res['coeff_0__attr_"real"'], sum(x), places=6)
+
+        x = [0, 1, 0, 0]
+        res = pd.Series(dict(fft_coefficient(x, param)))
+        # see documentation of fft in numpy
+        # should return array([1. + 0.j, 0. - 1.j, -1. + 0.j])
+        self.assertAlmostEqual(res['coeff_0__attr_"imag"'], 0, places=6)
+        self.assertAlmostEqual(res['coeff_0__attr_"real"'], 1, places=6)
+        self.assertAlmostEqual(res['coeff_1__attr_"imag"'], -1, places=6)
+        self.assertAlmostEqual(res['coeff_1__attr_"real"'], 0, places=6)
+        self.assertAlmostEqual(res['coeff_2__attr_"imag"'], 0, places=6)
+        self.assertAlmostEqual(res['coeff_2__attr_"real"'], -1, places=6)
 
     def test_number_peaks(self):
         x = np.array([0, 1, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1])

--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -310,8 +310,19 @@ class FeatureCalculationTestCase(TestCase):
         self.assertIsNanOnAllArrayTypes(ratio_value_number_to_time_series_length, [])
 
     def test_fft_coefficient(self):
-        pass
         # todo: add unit test
+
+        x = range(10)
+        param = [{"coeff": 0, "attr": "real"}, {"coeff": 1, "attr": "real"}, {"coeff": 2, "attr": "real"},
+                 {"coeff": 0, "attr": "imag"}, {"coeff": 1, "attr": "imag"}, {"coeff": 2, "attr": "imag"}]
+        expected_index = ['coeff_0__attr_"real"', 'coeff_1__attr_"real"', 'coeff_2__attr_"real"',
+                          'coeff_0__attr_"imag"', 'coeff_1__attr_"imag"', 'coeff_2__attr_"imag"']
+
+        res = pd.Series(dict(fft_coefficient(x, param)))
+        print(res)
+        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertAlmostEqual(res['coeff_0__attr_"imag"'], 0, places=1)
+        self.assertAlmostEqual(res['coeff_0__attr_"real"'], sum(x), places=1)
 
     def test_number_peaks(self):
         x = np.array([0, 1, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1])

--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -334,6 +334,15 @@ class FeatureCalculationTestCase(TestCase):
         self.assertAlmostEqual(res['coeff_2__attr_"imag"'], 0, places=6)
         self.assertAlmostEqual(res['coeff_2__attr_"real"'], -1, places=6)
 
+        # test what happens if coeff is biger than time series lenght
+        x = range(5)
+        param = [{"coeff": 10, "attr": "real"}]
+        expected_index = ['coeff_10__attr_"real"']
+
+        res = pd.Series(dict(fft_coefficient(x, param)))
+        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertIsNaN(res['coeff_10__attr_"real"'])
+
     def test_number_peaks(self):
         x = np.array([0, 1, 2, 1, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1])
         self.assertEqualOnAllArrayTypes(number_peaks, x, 2, 1)

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -737,17 +737,13 @@ def fft_coefficient(x, param):
     :return type: pandas.Series
     """
 
-    coefficients = set([config["coeff"] for config in param])
-    for coeff in coefficients:
-        if coeff < 0:
-            raise ValueError("Coefficients must be positive or zero.")
+    assert min([config["coeff"] for config in param]) >= 0, "Coefficients must be positive or zero."
+    assert set([config["attr"] for config in param]) == set("imag", "real"), 'Attribute must be "real" or "imag"'
 
-    maximum_coefficient = max(max(coefficients), 1)
-    fft = np.fft.rfft(x, min(len(x), 2 * maximum_coefficient))
+    fft = np.fft.rfft(x)
 
-    res = [fft[q] if q < len(fft) else 0 for q in coefficients]
-    res = [r.real if isinstance(r, complex) else r for r in res]
-    index = ["coeff_{}".format(q) for q in coefficients]
+    res = [getattr(fft[config["coeff"]], config["attr"]) for config in param]
+    index = ["coeff_{}__attr_{}".format(config["coeff"], config["attr"]) for config in param]
     return zip(index, res)
 
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -742,7 +742,7 @@ def fft_coefficient(x, param):
 
     fft = np.fft.rfft(x)
 
-    res = [getattr(fft[config["coeff"]], config["attr"]) for config in param]
+    res = [getattr(fft[config["coeff"]], config["attr"]) if config["coeff"] < len(fft) else np.NaN for config in param]
     index = ['coeff_{}__attr_"{}"'.format(config["coeff"], config["attr"]) for config in param]
     return zip(index, res)
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -743,7 +743,7 @@ def fft_coefficient(x, param):
     fft = np.fft.rfft(x)
 
     res = [getattr(fft[config["coeff"]], config["attr"]) for config in param]
-    index = ["coeff_{}__attr_{}".format(config["coeff"], config["attr"]) for config in param]
+    index = ['coeff_{}__attr_"{}"'.format(config["coeff"], config["attr"]) for config in param]
     return zip(index, res)
 
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -738,7 +738,7 @@ def fft_coefficient(x, param):
     """
 
     assert min([config["coeff"] for config in param]) >= 0, "Coefficients must be positive or zero."
-    assert set([config["attr"] for config in param]) == set("imag", "real"), 'Attribute must be "real" or "imag"'
+    assert set([config["attr"] for config in param]) == set(["imag", "real"]), 'Attribute must be "real" or "imag"'
 
     fft = np.fft.rfft(x)
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -726,9 +726,12 @@ def fft_coefficient(x, param):
     Calculates the fourier coefficients of the one-dimensional discrete Fourier Transform for real input by fast
     fourier transformation algorithm
 
+    .. math::
+        A_k =  \\sum_{m=0}^{n-1} a_m \\exp \\left \\{ -2 \\pi i \\frac{m k}{n} \\right \\}, \\qquad k = 0, \\ldots , n-1.
+
     :param x: the time series to calculate the feature of
     :type x: pandas.Series
-    :param param: contains dictionaries {"coeff": x} with x int and x >= 0
+    :param param: contains dictionaries {"coeff": x, "attr": s} with x int and x >= 0, s str and in ["real", "imag"]
     :type param: list
     :return: the different feature values
     :return type: pandas.Series

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -738,7 +738,7 @@ def fft_coefficient(x, param):
     """
 
     assert min([config["coeff"] for config in param]) >= 0, "Coefficients must be positive or zero."
-    assert set([config["attr"] for config in param]) == set(["imag", "real"]), 'Attribute must be "real" or "imag"'
+    assert set([config["attr"] for config in param]) <= set(["imag", "real"]), 'Attribute must be "real" or "imag"'
 
     fft = np.fft.rfft(x)
 

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -14,6 +14,8 @@ import numpy as np
 from builtins import range
 from past.builtins import basestring
 
+from itertools import product
+
 from tsfresh.feature_extraction import feature_calculators
 from tsfresh.utilities.string_manipulation import get_config_from_string
 
@@ -117,7 +119,7 @@ class ComprehensiveFCParameters(dict):
             "ar_coefficient": [{"coeff": coeff, "k": k} for coeff in range(5) for k in [10]],
             "mean_abs_change_quantiles": [{"ql": ql, "qh": qh}
                                           for ql in [0., .2, .4, .6, .8] for qh in [.2, .4, .6, .8, 1.]],
-            "fft_coefficient": [{"coeff": coeff} for coeff in range(0, 10)],
+            "fft_coefficient": [{"coeff": k, "attr": a} for a, k in product(["real", "imag"], range(100))],
             "value_count": [{"value": value} for value in [0, 1, np.NaN, np.PINF, np.NINF]],
             "range_count": [{"min": -1, "max": 1}],
             "approximate_entropy": [{"m": 2, "r": r} for r in [.1, .3, .5, .7, .9]],


### PR DESCRIPTION
I ditched the "max_lag" as it truncated the input.

I added some unit tests and updated the documentation

See issue #228 for a detailed discussion