### PR TITLE
update human activity notebook with new impute

### DIFF
--- a/notebooks/human_activity_recognition_multi_class_example.ipynb
+++ b/notebooks/human_activity_recognition_multi_class_example.ipynb
@@ -177,7 +177,6 @@
    "outputs": [],
    "source": [
     "extraction_settings = ComprehensiveFCParameters()\n",
-    "extraction_settings.IMPUTE = impute    # Fill in Infs and NaNs"
    ]
   },
   {
@@ -339,7 +338,7 @@
     }
    ],
    "source": [
-    "%time X = extract_features(master_df, column_id=1, default_fc_parameters=extraction_settings);"
+    "%time X = extract_features(master_df, column_id=1, impute_function=impute, default_fc_parameters=extraction_settings);"
    ]
   },
   {


### PR DESCRIPTION
hi, i noticed in the latest version of tsfresh you use the new method of passing in your impute function to `extract_features` instead of setting it in the `extraction_settings`. So I updated the notebook so others would see this (it tripped me up for a bit, as I was wondering why my data wasn't being imputed).

let me know if there's anything else i need to do for this PR.