### PR TITLE
fix extra newline in human activity recognition notebook

### DIFF
--- a/notebooks/human_activity_recognition_multi_class_example.ipynb
+++ b/notebooks/human_activity_recognition_multi_class_example.ipynb
@@ -176,7 +176,7 @@
    },
    "outputs": [],
    "source": [
-    "extraction_settings = ComprehensiveFCParameters()\n",
+    "extraction_settings = ComprehensiveFCParameters()"
    ]
   },
   {


### PR DESCRIPTION
sorry, just tried running the notebook and realized i need to get rid of the newline and comma after deleting the line as well.

that's what i get for editing the ipynb file in vim