### PR TITLE
Fix impute

### DIFF
--- a/tests/utilities/test_dataframe_functions.py
+++ b/tests/utilities/test_dataframe_functions.py
@@ -430,7 +430,7 @@ class ImputeTestCase(TestCase):
         dataframe_functions.impute(df)
 
         self.assertEqual(list(df.value_a), [0, 1, 2, 1])
-        self.assertEqual(list(df.value_b), [1, 3, 2, 1.5])
+        self.assertEqual(list(df.value_b), [1, 2, 2, 1.5])
         self.assertEqual(list(df.value_c), [0, -3, -3, 3])
 
         df = pd.DataFrame(np.transpose([[0, 1, 2, np.NaN], [1, np.PINF, 2, 3], [np.PINF, -3, np.NINF, 3]]),

--- a/tests/utilities/test_dataframe_functions.py
+++ b/tests/utilities/test_dataframe_functions.py
@@ -424,19 +424,23 @@ class ImputeTestCase(TestCase):
         self.assertEqual(list(df.value_b), [1, 3, 2, 3])
         self.assertEqual(list(df.value_c), [1, -3, -3, 3])
 
-        df = pd.DataFrame(np.transpose([[0, 1, 2, np.NaN], [1, np.PINF, 2, 3], [1, -3, np.NINF, 3]]),
+        df = pd.DataFrame(np.transpose([[0, 1, 2, np.NaN], [1, np.PINF, 2, np.NaN], [np.NaN, -3, np.NINF, 3]]),
                           columns=["value_a", "value_b", "value_c"])
         df = df.astype(np.float64, inplace=True)
         dataframe_functions.impute(df)
 
-        df = pd.DataFrame(np.transpose([[0, 1, 2, np.NaN], [1, np.PINF, 2, 3], [1, -3, np.NINF, 3]]),
+        self.assertEqual(list(df.value_a), [0, 1, 2, 1])
+        self.assertEqual(list(df.value_b), [1, 3, 2, 1.5])
+        self.assertEqual(list(df.value_c), [0, -3, -3, 3])
+
+        df = pd.DataFrame(np.transpose([[0, 1, 2, np.NaN], [1, np.PINF, 2, 3], [np.PINF, -3, np.NINF, 3]]),
                           columns=["value_a", "value_b", "value_c"])
         df = df.astype(np.float32, inplace=True)
         dataframe_functions.impute(df)
 
         self.assertEqual(list(df.value_a), [0, 1, 2, 1])
         self.assertEqual(list(df.value_b), [1, 3, 2, 3])
-        self.assertEqual(list(df.value_c), [1, -3, -3, 3])
+        self.assertEqual(list(df.value_c), [3, -3, -3, 3])
 
     def test_impute_range(self):
         def get_df():

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -134,9 +134,9 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
                          "to replace")
 
     # Make the replacement dataframes as large as the real one
-    col_to_max = pd.DataFrame([col_to_max]*len(df_impute))
-    col_to_min = pd.DataFrame([col_to_min]*len(df_impute))
-    col_to_median = pd.DataFrame([col_to_median]*len(df_impute))
+    col_to_max = pd.DataFrame([col_to_max]*len(df_impute), index=df_impute.index)
+    col_to_min = pd.DataFrame([col_to_min]*len(df_impute), index=df_impute.index)
+    col_to_median = pd.DataFrame([col_to_median]*len(df_impute), index=df_impute.index)
 
     df_impute.where(df_impute.values != np.PINF, other=col_to_max, inplace=True)
     df_impute.where(df_impute.values != np.NINF, other=col_to_min, inplace=True)

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -133,24 +133,14 @@ def impute_dataframe_range(df_impute, col_to_max, col_to_min, col_to_median):
         raise ValueError("Some of the dictionaries col_to_median, col_to_max, col_to_min contains non finite values "
                          "to replace")
 
-    # Replacing values
-    # +inf -> max
-    indices = np.nonzero(df_impute.values == np.PINF)
-    if len(indices[0]) > 0:
-        replacement = [col_to_max[columns[i]] for i in indices[1]]
-        df_impute.iloc[indices] = replacement
+    # Make the replacement dataframes as large as the real one
+    col_to_max = pd.DataFrame([col_to_max]*len(df_impute))
+    col_to_min = pd.DataFrame([col_to_min]*len(df_impute))
+    col_to_median = pd.DataFrame([col_to_median]*len(df_impute))
 
-    # -inf -> min
-    indices = np.nonzero(df_impute.values == np.NINF)
-    if len(indices[0]) > 0:
-        replacement = [col_to_min[columns[i]] for i in indices[1]]
-        df_impute.iloc[indices] = replacement
-
-    # NaN -> median
-    indices = np.nonzero(np.isnan(df_impute.values))
-    if len(indices[0]) > 0:
-        replacement = [col_to_median[columns[i]] for i in indices[1]]
-        df_impute.iloc[indices] = replacement
+    df_impute.where(df_impute.values != np.PINF, other=col_to_max, inplace=True)
+    df_impute.where(df_impute.values != np.NINF, other=col_to_min, inplace=True)
+    df_impute.where(~np.isnan(df_impute.values), other=col_to_median, inplace=True)
 
     df_impute.astype(np.float64, copy=False)
     return df_impute


### PR DESCRIPTION
This fixes both a unittest, which was wrong (and had the same problem as the bug in our impute function) and the impute function itself.

Also, it speeds up the impute by a large amount (using more memory though) - it is basically calculated in notime now.

This should fix #272.