### PR TITLE
Change autocorrelation feature calculator (#273)

### DIFF
--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -606,7 +606,12 @@ class FeatureCalculationTestCase(TestCase):
         self.assertAlmostEqualOnAllArrayTypes(autocorrelation, [1, 2, 1, 2, 1, 2], 1, 2)
         self.assertAlmostEqualOnAllArrayTypes(autocorrelation, [1, 2, 1, 2, 1, 2], -1, 3)
         self.assertAlmostEqualOnAllArrayTypes(autocorrelation, [1, 2, 1, 2, 1, 2], 1, 4)
+        # Autocorrelation lag is larger than length of the time series
         self.assertIsNanOnAllArrayTypes(autocorrelation, [1, 2, 1, 2, 1, 2], 200)
+        self.assertIsNanOnAllArrayTypes(autocorrelation, [np.nan], 0)
+        self.assertIsNanOnAllArrayTypes(autocorrelation, [], 0)
+        # time series with length 1 has no variance, therefore no result for autocorrelation at lag 0
+        self.assertIsNanOnAllArrayTypes(autocorrelation, [1], 0)
 
     def test_quantile(self):
         self.assertAlmostEqualOnAllArrayTypes(quantile, [1, 1, 1, 3, 4, 7, 9, 11, 13, 13], 1.0, 0.2)

--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -606,6 +606,7 @@ class FeatureCalculationTestCase(TestCase):
         self.assertAlmostEqualOnAllArrayTypes(autocorrelation, [1, 2, 1, 2, 1, 2], 1, 2)
         self.assertAlmostEqualOnAllArrayTypes(autocorrelation, [1, 2, 1, 2, 1, 2], -1, 3)
         self.assertAlmostEqualOnAllArrayTypes(autocorrelation, [1, 2, 1, 2, 1, 2], 1, 4)
+        self.assertAlmostEqualOnAllArrayTypes(autocorrelation, pd.Series([0, 1, 2, 0, 1, 2]), -0.75, 2)
         # Autocorrelation lag is larger than length of the time series
         self.assertIsNanOnAllArrayTypes(autocorrelation, [1, 2, 1, 2, 1, 2], 200)
         self.assertIsNanOnAllArrayTypes(autocorrelation, [np.nan], 0)


### PR DESCRIPTION
* I was mistaken, there are already unit tests for auto-
correlation

* pd.Series.autocorr() and statsmodels.tsa.stattools.acf yield
different results

* autocorrelation now mimics the "acf" behaviour, but calculates
a single lag and not all lags up to the specified one

* The calulation coincides now with the formula at
https://en.wikipedia.org/wiki/Autocorrelation#Estimation

* Added some tests