### PR TITLE
Add partial autocorrelation feature calculator

### DIFF
--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -159,6 +159,74 @@ class FeatureCalculationTestCase(TestCase):
         res = dict(agg_autocorrelation(x, param=param))["f_agg_\"median\""]
         self.assertAlmostEqual(res, expected_res, places=4)
 
+    def test_partial_autocorrelation(self):
+
+        # Test for altering time series
+        # len(x) < max_lag
+        param = [{"lag": lag} for lag in range(10)]
+        x = [1, 2, 1, 2, 1, 2]
+        expected_res = [("lag_0", 1.0), ("lag_1", -1.0), ("lag_2", np.nan)]
+        res = partial_autocorrelation(x, param=param)
+        self.assertAlmostEqual(res[0][1], expected_res[0][1], places=4)
+        self.assertAlmostEqual(res[1][1], expected_res[1][1], places=4)
+        self.assertIsNaN(res[2][1])
+
+        # Linear signal
+        param = [{"lag": lag} for lag in range(10)]
+        x = np.linspace(0, 1, 3000)
+        expected_res = [("lag_0", 1.0), ("lag_1", 1.0), ("lag_2", 0)]
+        res = partial_autocorrelation(x, param=param)
+        self.assertAlmostEqual(res[0][1], expected_res[0][1], places=2)
+        self.assertAlmostEqual(res[1][1], expected_res[1][1], places=2)
+        self.assertAlmostEqual(res[2][1], expected_res[2][1], places=2)
+
+        # Random noise
+        np.random.seed(42)
+        x = np.random.normal(size=3000)
+        param = [{"lag": lag} for lag in range(10)]
+        expected_res = [("lag_0", 1.0), ("lag_1", 0), ("lag_2", 0)]
+        res = partial_autocorrelation(x, param=param)
+        self.assertAlmostEqual(res[0][1], expected_res[0][1], places=1)
+        self.assertAlmostEqual(res[1][1], expected_res[1][1], places=1)
+        self.assertAlmostEqual(res[2][1], expected_res[2][1], places=1)
+
+        # On a simulated AR process
+        np.random.seed(42)
+        param = [{"lag": lag} for lag in range(10)]
+        # Simulate AR process
+        T = 3000
+        epsilon = np.random.randn(T)
+        x = np.repeat(1.0, T)
+        for t in range(T - 1):
+            x[t + 1] = 0.5 * x[t] + 2 + epsilon[t]
+        expected_res = [("lag_0", 1.0), ("lag_1", 0.5), ("lag_2", 0)]
+        res = partial_autocorrelation(x, param=param)
+        self.assertAlmostEqual(res[0][1], expected_res[0][1], places=1)
+        self.assertAlmostEqual(res[1][1], expected_res[1][1], places=1)
+        self.assertAlmostEqual(res[2][1], expected_res[2][1], places=1)
+
+        # Some pathological cases
+        param = [{"lag": lag} for lag in range(10)]
+        # List of length 1
+        res = partial_autocorrelation([1], param=param)
+        for lag_no, lag_val in res:
+            self.assertIsNaN(lag_val)
+        # Empty list
+        res = partial_autocorrelation([], param=param)
+        for lag_no, lag_val in res:
+            self.assertIsNaN(lag_val)
+        # List contains only np.nan
+        res = partial_autocorrelation([np.nan, np.nan, np.nan], param=param)
+        for lag_no, lag_val in res:
+            self.assertIsNaN(lag_val)
+        # List contains only zeros
+        res = partial_autocorrelation(np.zeros(100), param=param)
+        for lag_no, lag_val in res:
+            if lag_no == "lag_0":
+                self.assertEqual(lag_val, 1.0)
+            else:
+                self.assertIsNaN(lag_val)
+
 
     def test_augmented_dickey_fuller(self):
         # todo: add unit test for the values of the test statistic

--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -215,10 +215,6 @@ class FeatureCalculationTestCase(TestCase):
         res = partial_autocorrelation([], param=param)
         for lag_no, lag_val in res:
             self.assertIsNaN(lag_val)
-        # List contains only np.nan
-        res = partial_autocorrelation([np.nan, np.nan, np.nan], param=param)
-        for lag_no, lag_val in res:
-            self.assertIsNaN(lag_val)
         # List contains only zeros
         res = partial_autocorrelation(np.zeros(100), param=param)
         for lag_no, lag_val in res:

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -24,7 +24,7 @@ import pandas as pd
 from scipy.signal import welch, cwt, ricker, find_peaks_cwt
 from statsmodels.tsa.ar_model import AR
 from statsmodels.tsa.stattools import adfuller
-from statsmodels.tsa.stattools import acf
+from statsmodels.tsa.stattools import acf, pacf
 from scipy.stats import linregress
 
 # todo: make sure '_' works in parameter names in all cases, add a warning if not
@@ -289,6 +289,58 @@ def agg_autocorrelation(x, param):
     else:
         a = acf(x, unbiased=True, fft=n > 1250)[1:]
     return [("f_agg_\"{}\"".format(config["f_agg"]), getattr(np, config["f_agg"])(a)) for config in param]
+
+
+@set_property("fctype", "combiner")
+def partial_autocorrelation(x, param):
+    """
+    Calculates the value of the partial autocorrelation function at the given lag. The lag `k` partial autocorrelation
+    of a time series :math:`\\lbrace x_t, t = 1 \\ldots T \\rbrace` equals the partial correlation of :math:`x_t` and
+    :math:`x_{t-k}`, adjusted for the intermediate variables
+    :math:`\\lbrace x_{t-1}, \\ldots, x_{t-k+1} \\rbrace` ([1]).
+    Following [2], it can be defined as
+
+    .. math::
+
+        \\alpha_k = \\frac{ Cov(x_t, x_{t-k} | x_{t-1}, \\ldots, x_{t-k+1})}
+        {\\sqrt{ Var(x_t | x_{t-1}, \\ldots, x_{t-k+1}) Var(x_{t-k} | x_{t-1}, \\ldots, x_{t-k+1} )}}
+
+    with (a) :math:`x_t = f(x_{t-1}, \\ldots, x_{t-k+1})` and (b) :math:`x_{t-k} = f(x_{t-1}, \\ldots, x_{t-k+1})`
+    being AR(k-1) models that can be fitted by OLS. Be aware that in (a), the regression is done on past values to
+    predict :math:`x_t` whereas in (b), future values are used to calculate the past value :math:`x_{t-k}`.
+    It is said in [1] that "for an AR(p), the partial autocorrelations [ :math:`\\alpha_k` ] will be nonzero for `k<=p`
+    and zero for `k>p`."
+    With this property, it is used to determine the lag of an AR-Process.
+
+    .. rubric:: References
+
+    |  [1] Box, G. E., Jenkins, G. M., Reinsel, G. C., & Ljung, G. M. (2015).
+    |  Time series analysis: forecasting and control. John Wiley & Sons.
+    |  [2] https://onlinecourses.science.psu.edu/stat510/node/62
+
+    :param x: the time series to calculate the feature of
+    :type x: pandas.Series
+    :param param: contains dictionaries {"lag": val} with int val indicating the lag to be returned
+    :type param: list
+    :return: the value of this feature
+    :return type: float
+    """
+    # Check the difference between demanded lags by param and possible lags to calculate (depends on len(x))
+    max_demanded_lag = max([lag["lag"] for lag in param])
+    n = len(x)
+
+    # Check if list is too short or consists only of NaNs
+    if n <= 1 or sum(np.isnan(x)) == n:
+        pacf_coeffs = [np.nan] * (max_demanded_lag + 1)
+    else:
+        if (n <= max_demanded_lag):
+            max_lag = n - 1
+        else:
+            max_lag = max_demanded_lag
+        pacf_coeffs = list(pacf(x, method="ld", nlags=max_lag))
+        pacf_coeffs = pacf_coeffs + [np.nan] * max(0, (max_demanded_lag - max_lag))
+
+    return [("lag_{}".format(lag["lag"]), pacf_coeffs[lag["lag"]]) for lag in param]
 
 
 @set_property("fctype", "combiner")

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -329,8 +329,8 @@ def partial_autocorrelation(x, param):
     max_demanded_lag = max([lag["lag"] for lag in param])
     n = len(x)
 
-    # Check if list is too short or consists only of NaNs
-    if n <= 1 or sum(np.isnan(x)) == n:
+    # Check if list is too short to make calculations
+    if n <= 1:
         pacf_coeffs = [np.nan] * (max_demanded_lag + 1)
     else:
         if (n <= max_demanded_lag):

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -110,6 +110,7 @@ class ComprehensiveFCParameters(dict):
             "quantile": [{"q": q} for q in [.1, .2, .3, .4, .6, .7, .8, .9]],
             "autocorrelation": [{"lag": lag} for lag in range(10)],
             "agg_autocorrelation": [{"f_agg": s} for s in ["mean", "median", "var"]],
+            "partial_autocorrelation": [{"lag": lag} for lag in range(10)],
             "number_cwt_peaks": [{"n": n} for n in [1, 5]],
             "number_peaks": [{"n": n} for n in [1, 3, 5, 10, 50]],
             "binned_entropy": [{"max_bins": max_bins} for max_bins in [10]],


### PR DESCRIPTION
* The PACF can be used to determine the lag p of an AR(p) process

* Comprehensive docstring

* Many tests added. Some may be discarded

* Use the option `method="ld"` which is fastest and does not throw
Singular Matrix Errors compared to "yw"

* The OLS method is buggy / wrong (see statsmodels issue #3839)

* Solves tsfresh issue #223