### PR TITLE
Add list of feature_calculators with sphinx autosummary extension

### DIFF
--- a/docs/_templates/module_functions_template.rst
+++ b/docs/_templates/module_functions_template.rst
@@ -1,0 +1,10 @@
+.. currentmodule:: {{ fullname }}
+
+{% block functions %}
+
+.. autosummary::
+{% for item in functions %}
+   {{ item }}
+{%- endfor %}
+
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,6 +110,10 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 keep_warnings = True
 
+# Boolean indicating whether to scan all found documents for autosummary
+# directives, and to generate stub pages for each
+autosummary_generate = True
+
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ The following chapters will explain the tsfresh package in detail:
    Module Reference <api/modules>
    Data Formats <text/data_formats>
    scikit-learn Transformers <text/sklearn_transformers>
+   List of Calculated Features <text/list_of_features>
    Feature Calculation <text/feature_calculation>
    Feature Calculator Settings <text/feature_extraction_settings>
    Feature Filtering <text/feature_filtering>

--- a/docs/text/feature_calculation.rst
+++ b/docs/text/feature_calculation.rst
@@ -7,7 +7,7 @@ Feature Calculation
 Overview on extracted features
 ''''''''''''''''''''''''''''''
 
-tsfresh calculates a comprehensive number of features in the
+*tsfresh* calculates a comprehensive number of features. All feature calculators are contained in the
 
 .. autosummary::
    :toctree: _generated
@@ -15,7 +15,9 @@ tsfresh calculates a comprehensive number of features in the
 
     tsfresh.feature_extraction.feature_calculators
 
-module. See this exhaustive list:
+submodule. 
+
+The following, exhaustive list contains all features that are calculated in the current version of *tsfresh*:
 
 .. include:: _generated/tsfresh.feature_extraction.feature_calculators.rst
 

--- a/docs/text/feature_calculation.rst
+++ b/docs/text/feature_calculation.rst
@@ -3,25 +3,6 @@
 Feature Calculation
 ===================
 
-
-Overview on extracted features
-''''''''''''''''''''''''''''''
-
-*tsfresh* calculates a comprehensive number of features. All feature calculators are contained in the
-
-.. autosummary::
-   :toctree: _generated
-   :template: module_functions_template.rst
-
-    tsfresh.feature_extraction.feature_calculators
-
-submodule. 
-
-The following, exhaustive list contains all features that are calculated in the current version of *tsfresh*:
-
-.. include:: _generated/tsfresh.feature_extraction.feature_calculators.rst
-
-
 Feature naming
 ''''''''''''''
 

--- a/docs/text/feature_calculation.rst
+++ b/docs/text/feature_calculation.rst
@@ -7,13 +7,18 @@ Feature Calculation
 Overview on extracted features
 ''''''''''''''''''''''''''''''
 
-tsfresh already calculates a comprehensive number of features. Follow this
-link to see a full list:
+tsfresh calculates a comprehensive number of features in the
 
 .. autosummary::
-    :toctree: _generated
+   :toctree: _generated
+   :template: module_functions_template.rst
 
     tsfresh.feature_extraction.feature_calculators
+
+module. See this exhaustive list:
+
+.. include:: _generated/tsfresh.feature_extraction.feature_calculators.rst
+
 
 Feature naming
 ''''''''''''''

--- a/docs/text/feature_calculation.rst
+++ b/docs/text/feature_calculation.rst
@@ -4,16 +4,16 @@ Feature Calculation
 ===================
 
 
-Overview on extracted feature
-'''''''''''''''''''''''''''''
+Overview on extracted features
+''''''''''''''''''''''''''''''
 
-tsfresh already calculates a comprehensive number of features. If you are interested in which features are calculated,
-just go to our
+tsfresh already calculates a comprehensive number of features. Follow this
+link to see a full list:
 
-:mod:`tsfresh.feature_extraction.feature_calculators`
+.. autosummary::
+    :toctree: _generated
 
-module. You will find the documentation of every calculated feature there.
-
+    tsfresh.feature_extraction.feature_calculators
 
 Feature naming
 ''''''''''''''

--- a/docs/text/list_of_features.rst
+++ b/docs/text/list_of_features.rst
@@ -1,0 +1,16 @@
+Overview on extracted features
+==============================
+
+*tsfresh* calculates a comprehensive number of features. All feature calculators are contained in the
+
+.. autosummary::
+   :toctree: _generated
+   :template: module_functions_template.rst
+
+    tsfresh.feature_extraction.feature_calculators
+
+submodule. 
+
+The following, exhaustive list contains all features that are calculated in the current version of *tsfresh*:
+
+.. include:: _generated/tsfresh.feature_extraction.feature_calculators.rst


### PR DESCRIPTION
* I did not go for a new file list_of_features.rst but included
it in the already present feature_calculation.rst to avoid
duplicates

* The list of functions is autogenerated

* It is accessible from the sidebar, but when you click on it, the
sidebar collapses (try it out!)

* the files are autogenerated in the _generate folder (no need for
version control)

* See also issue #285