### PR TITLE
Bugfix - augmented Dickey-Fuller feature extractor improperly quoted parameter

### DIFF
--- a/tests/feature_extraction/test_feature_calculations.py
+++ b/tests/feature_extraction/test_feature_calculations.py
@@ -234,13 +234,13 @@ class FeatureCalculationTestCase(TestCase):
         np.random.seed(seed=42)
         x = np.cumsum(np.random.uniform(size=100))
         param = [{"attr": "teststat"}, {"attr": "pvalue"}, {"attr": "usedlag"}]
-        expected_index = ['attr_teststat', 'attr_pvalue', 'attr_usedlag']
+        expected_index = ['attr_"teststat"', 'attr_"pvalue"', 'attr_"usedlag"']
 
         res = augmented_dickey_fuller(x=x, param=param)
         res = pd.Series(dict(res))
         six.assertCountEqual(self, list(res.index), expected_index)
-        self.assertGreater(res["attr_pvalue"], 0.10)
-        self.assertEqual(res["attr_usedlag"], 0)
+        self.assertGreater(res['attr_"pvalue"'], 0.10)
+        self.assertEqual(res['attr_"usedlag"'], 0)
 
         # H0 should be rejected for AR(1) model with x_{t} = 1/2 x_{t-1} + e_{t}
         np.random.seed(seed=42)
@@ -251,13 +251,13 @@ class FeatureCalculationTestCase(TestCase):
         for i in range(1, m):
             x[i] = x[i-1] * 0.5 + e[i]
         param = [{"attr": "teststat"}, {"attr": "pvalue"}, {"attr": "usedlag"}]
-        expected_index = ['attr_teststat', 'attr_pvalue', 'attr_usedlag']
+        expected_index = ['attr_"teststat"', 'attr_"pvalue"', 'attr_"usedlag"']
 
         res = augmented_dickey_fuller(x=x, param=param)
         res = pd.Series(dict(res))
         six.assertCountEqual(self, list(res.index), expected_index)
-        self.assertLessEqual(res["attr_pvalue"], 0.05)
-        self.assertEqual(res["attr_usedlag"], 0)
+        self.assertLessEqual(res['attr_"pvalue"'], 0.05)
+        self.assertEqual(res['attr_"usedlag"'], 0)
 
         # Check if LinAlgError and ValueError are catched
         res_linalg_error = augmented_dickey_fuller(x=np.repeat(np.nan, 100), param=param)
@@ -488,7 +488,7 @@ class FeatureCalculationTestCase(TestCase):
         param = [{"q": 0.5}]
         expected_index = ["q_0.5"]
         res = index_mass_quantile(x, param)
-        
+
         res = pd.Series(dict(res))
         six.assertCountEqual(self, list(res.index), expected_index)
         self.assertAlmostEqual(res["q_0.5"], 0.5, places=1)
@@ -498,7 +498,7 @@ class FeatureCalculationTestCase(TestCase):
         param = [{"q": 0.5}]
         expected_index = ["q_0.5"]
         res = index_mass_quantile(x[x > 0], param)
-        
+
         res = pd.Series(dict(res))
         six.assertCountEqual(self, list(res.index), expected_index)
         self.assertAlmostEqual(res["q_0.5"], 0.5, places=1)
@@ -507,7 +507,7 @@ class FeatureCalculationTestCase(TestCase):
         param = [{"q": 0.5}, {"q": 0.99}]
         expected_index = ["q_0.5", "q_0.99"]
         res = index_mass_quantile(x, param)
-        
+
         res = pd.Series(dict(res))
         six.assertCountEqual(self, list(res.index), expected_index)
         self.assertAlmostEqual(res["q_0.5"], 1, places=1)
@@ -518,7 +518,7 @@ class FeatureCalculationTestCase(TestCase):
         expected_index = ["q_0.3", "q_0.6",
                           "q_0.9"]
         res = index_mass_quantile(x, param)
-        
+
         res = pd.Series(dict(res))
 
         six.assertCountEqual(self, list(res.index), expected_index)
@@ -530,7 +530,7 @@ class FeatureCalculationTestCase(TestCase):
         param = [{"q": 0.5}]
         expected_index = ["q_0.5"]
         res = index_mass_quantile(x, param)
-        
+
         res = pd.Series(dict(res))
         six.assertCountEqual(self, list(res.index), expected_index)
         self.assertTrue(np.isnan(res["q_0.5"]))
@@ -539,7 +539,7 @@ class FeatureCalculationTestCase(TestCase):
         param = [{"q": 0.5}]
         expected_index = ["q_0.5"]
         res = index_mass_quantile(x, param)
-        
+
         res = pd.Series(dict(res))
         six.assertCountEqual(self, list(res.index), expected_index)
         self.assertTrue(np.isnan(res["q_0.5"]))
@@ -571,7 +571,7 @@ class FeatureCalculationTestCase(TestCase):
 
         res = cwt_coefficients(x, param)
 
-        
+
         res = pd.Series(dict(res))
 
         # todo: add unit test for the values
@@ -591,7 +591,7 @@ class FeatureCalculationTestCase(TestCase):
         res = ar_coefficient(x, param)
         expected_index = ["k_1__coeff_0", "k_1__coeff_1"]
 
-        
+
         res = pd.Series(dict(res))
         six.assertCountEqual(self, list(res.index), expected_index)
         self.assertAlmostEqual(res["k_1__coeff_0"], 1, places=2)
@@ -611,7 +611,7 @@ class FeatureCalculationTestCase(TestCase):
                           "k_2__coeff_0", "k_2__coeff_1",
                           "k_2__coeff_2", "k_2__coeff_3"]
 
-        
+
         res = pd.Series(dict(res))
 
         self.assertIsInstance(res, pd.Series)
@@ -711,7 +711,7 @@ class FeatureCalculationTestCase(TestCase):
                                               ql=0.1, qh=1, isabs=True, f_agg="mean")
         self.assertAlmostEqualOnAllArrayTypes(change_quantiles, [0, 1, -9, 0, 0, 1, 0], 0.75,
                                               ql=0.1, qh=1, isabs=True, f_agg="mean")
-        
+
         self.assertAlmostEqualOnAllArrayTypes(change_quantiles, list(range(10)), 1,
                                               ql=0.1, qh=0.9, isabs=False, f_agg="mean")
         self.assertAlmostEqualOnAllArrayTypes(change_quantiles, list(range(10)), 0,
@@ -793,7 +793,7 @@ class FeatureCalculationTestCase(TestCase):
         x = np.zeros(1000)
 
         res = friedrich_coefficients(x, param)
-        
+
         res = pd.Series(dict(res))
 
         expected_index = ["m_2__r_30__coeff_0",
@@ -848,7 +848,7 @@ class FeatureCalculationTestCase(TestCase):
         param = [{"attr": "rvalue"}]
         res = linear_trend(x, param)
 
-        
+
         res = pd.Series(dict(res))
 
         self.assertLess(abs(res["attr_\"rvalue\""]), 0.1)
@@ -858,7 +858,7 @@ class FeatureCalculationTestCase(TestCase):
         param = [{"attr": "intercept"}, {"attr": "slope"}]
         res = linear_trend(x, param)
 
-        
+
         res = pd.Series(dict(res))
 
         self.assertAlmostEquals(res["attr_\"intercept\""], 42)
@@ -919,7 +919,7 @@ class FeatureCalculationTestCase(TestCase):
         x = pd.Series([np.NaN, np.NaN, np.NaN, -3, -3, -3])
         res = agg_linear_trend(x=x, param=param)
 
-        
+
         res = pd.Series(dict(res))
 
         self.assertIsNaN(res['f_agg_"max"__chunk_len_3__attr_"intercept"'])
@@ -934,7 +934,7 @@ class FeatureCalculationTestCase(TestCase):
         x = pd.Series([np.NaN, np.NaN, -3, -3, -3, -3])
         res = agg_linear_trend(x=x, param=param)
 
-        
+
         res = pd.Series(dict(res))
 
         self.assertAlmostEquals(res['f_agg_"max"__chunk_len_3__attr_"intercept"'], -3)

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -366,7 +366,7 @@ def augmented_dickey_fuller(x, param):
     except ValueError:  # occurs if sample size is too small
         res = np.NaN, np.NaN, np.NaN
 
-    return [("attr_{}".format(config["attr"]),
+    return [('attr_"{}""'.format(config["attr"]),
                   res[0] if config["attr"] == "teststat"
              else res[1] if config["attr"] == "pvalue"
              else res[2] if config["attr"] == "usedlag" else np.NaN)
@@ -1235,7 +1235,7 @@ def sample_entropy(x):
 
     |  [1] http://en.wikipedia.org/wiki/Sample_Entropy
     |  [2] https://www.ncbi.nlm.nih.gov/pubmed/10843903?dopt=Abstract
-    
+
     :param x: the time series to calculate the feature of
     :type x: pandas.Series
     :param tolerance: normalization factor; equivalent to the common practice of expressing the tolerance as r times \

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -366,7 +366,7 @@ def augmented_dickey_fuller(x, param):
     except ValueError:  # occurs if sample size is too small
         res = np.NaN, np.NaN, np.NaN
 
-    return [('attr_"{}""'.format(config["attr"]),
+    return [('attr_"{}"'.format(config["attr"]),
                   res[0] if config["attr"] == "teststat"
              else res[1] if config["attr"] == "pvalue"
              else res[2] if config["attr"] == "usedlag" else np.NaN)


### PR DESCRIPTION
The aforementioned feature extractor would put `attr_usedlag` in the column title, causing `get_config_from_string` to parse the attribute correctly. Added quotes like in the FFT feature extractor to fix this, so the resulting column title should be `attr_"usedlag"` instead.