### PR TITLE
adding binder requirements + badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Gitter chat](https://badges.gitter.im/tsfresh/Lobby.svg)](https://gitter.im/tsfresh/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
 ![py27 status](https://img.shields.io/badge/python2.7-supported-green.svg)
 [![py352 status](https://img.shields.io/badge/python3.5.2-supported-green.svg)](https://github.com/blue-yonder/tsfresh/issues/8)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/blue-yonder/tsfresh/master?filepath=notebooks)
 
 
 

--- a/binder/generate_binder_requirements.py
+++ b/binder/generate_binder_requirements.py
@@ -1,0 +1,16 @@
+from glob import glob
+
+use_files = ["../requirements.txt", "../test-requirements.txt"]
+files = set()
+
+# Collect a list of dependencies
+for ifile in use_files:
+    with open(ifile, 'r') as ff:
+        lines = ff.readlines()
+        files = files.union(lines)
+
+# Sort and save
+files = list(files)
+files.sort()
+with open('./requirements.txt', 'w') as ff:
+    ff.writelines(files)

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,16 +1,22 @@
-requests>=2.9.1
-numpy>=1.10.4
-pandas>=0.20.3
-scipy>=0.17.0
-statsmodels>=0.6.1
-patsy>=0.4.1
-scikit-learn>=0.17.1
-future>=0.16.0
-six>=1.10.0
-tqdm>=4.10.0
-ipaddress>=1.0.18; python_version <= '2.7'
 dask>=0.15.2
 distributed>=1.18.3
-tsfresh
-seaborn
-matplotlib
+future>=0.16.0
+ipaddress>=1.0.18; python_version <= '2.7'
+ipython>=5.3.0
+matplotlib>=2.0.0
+mock>=2.0.0
+notebook>=4.4.1
+numpy>=1.10.4
+pandas-datareader>=0.5.0
+pandas>=0.20.3
+patsy>=0.4.1
+pytest-cov>=2.3.1
+pytest-xdist>=1.15.0
+pytest>=3.0.2
+requests>=2.9.1
+scikit-learn>=0.17.1
+scipy>=0.17.0
+seaborn>=0.7.1
+six>=1.10.0
+statsmodels>=0.6.1
+tqdm>=4.10.0

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,16 @@
+requests>=2.9.1
+numpy>=1.10.4
+pandas>=0.20.3
+scipy>=0.17.0
+statsmodels>=0.6.1
+patsy>=0.4.1
+scikit-learn>=0.17.1
+future>=0.16.0
+six>=1.10.0
+tqdm>=4.10.0
+ipaddress>=1.0.18; python_version <= '2.7'
+dask>=0.15.2
+distributed>=1.18.3
+tsfresh
+seaborn
+matplotlib


### PR DESCRIPTION
This is a quick PR to add some pieces necessary to allow the examples in this repo to run on `mybinder.org`. This would make it possible for people to run your example notebooks interactively in the cloud by clicking on the badge in your README (or just going to the URL).

Basically all I did was copy over your requirements.txt file to a `binder` folder and added a few extra dependencies that were called from the notebooks (including the `tsfresh` library itself). Let me know if there's another way you'd prefer to handle dependencies, or if you have other questions in general. I think it'd be useful for people to be able to run the examples interactively without installing `tsfresh` / dependencies on their own machine!

Here's what would happen if people go to the binder-version of this repo (click link below) though note that currently there are dependencies missing that need to be installed, such as matplotlib (that's what this PR is addressing)

https://mybinder.org/v2/gh/blue-yonder/tsfresh/master?filepath=notebooks