### PR TITLE
Correct shell syntax in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ jobs:
     - stage: Run unit tests and deploy
       script: 
         - sed -i 's/\-n auto/\-n 2/g' setup.cfg
-        - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master']; then py.test tests/units -n2; else python setup.py test; fi"
+        - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then py.test tests/units -n2; else python setup.py test; fi"
       python: 2.7.11
       after_success:
         - coveralls
     - stage: Run unit tests and deploy
       script:
         - sed -i 's/\-n auto/\-n 2/g' setup.cfg
-        - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master']; then py.test tests/units -n2; else python setup.py test; fi"
+        - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then py.test tests/units -n2; else python setup.py test; fi"
       python: 3.5.2
       deploy:
         provider: pypi


### PR DESCRIPTION
This seem to break Travis builds at times - https://travis-ci.org/blue-yonder/tsfresh/jobs/334302177#L748

```
$ if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master']; then py.test tests/units -n2; else python setup.py test; fi
/home/travis/.travis/job_stages: line 57: [: missing `]'
============================= test session starts ==============================
```

Broken in commit - https://github.com/blue-yonder/tsfresh/commit/840a3d9ee94bed58c4707c273ea1a2762dabaadc#diff-354f30a63fb0907d4ad57269548329e3R20

Found debugging for https://github.com/blue-yonder/tsfresh/issues/369