### PR TITLE
fix for index preservation and test cases.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,3 @@ tqdm>=4.10.0
 ipaddress>=1.0.18; python_version <= '2.7'
 dask>=0.15.2
 distributed>=1.18.3
-mock>=2.0.0
-nbformat>=4.4.0
-pytest>=3.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ tqdm>=4.10.0
 ipaddress>=1.0.18; python_version <= '2.7'
 dask>=0.15.2
 distributed>=1.18.3
+mock>=2.0.0
+nbformat>=4.4.0
+pytest>=3.7.1

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -24,6 +24,22 @@ class DataTestCase(TestCase):
         df = pd.DataFrame({"id": cid, "kind": ckind, "sort": csort, "val": cval})
         return df.set_index("id", drop=False)
 
+    def create_test_data_nearly_numerical_indices(self):
+        cid = "99999_9999_" + pd.Series(np.repeat([10, 500], 40)).astype(str)
+        ckind = np.repeat(["a", "b", "a", "b"], 20)
+        csort = [30, 53, 26, 35, 42, 25, 17, 67, 20, 68, 46, 12, 0, 74, 66, 31, 32,
+                 2, 55, 59, 56, 60, 34, 69, 47, 15, 49, 8, 50, 73, 23, 62, 24, 33,
+                 22, 70, 3, 38, 28, 75, 39, 36, 64, 13, 72, 52, 40, 16, 58, 29, 63,
+                 79, 61, 78, 1, 10, 4, 6, 65, 44, 54, 48, 11, 14, 19, 43, 76, 7,
+                 51, 9, 27, 21, 5, 71, 57, 77, 41, 18, 45, 37]
+        cval = [11, 9, 67, 45, 30, 58, 62, 19, 56, 29, 0, 27, 36, 43, 33, 2, 24,
+                71, 41, 28, 50, 40, 39, 7, 53, 23, 16, 37, 66, 38, 6, 47, 3, 61,
+                44, 42, 78, 31, 21, 55, 15, 35, 25, 32, 69, 65, 70, 64, 51, 46, 5,
+                77, 26, 73, 76, 75, 72, 74, 10, 57, 4, 14, 68, 22, 18, 52, 54, 60,
+                79, 12, 49, 63, 8, 59, 1, 13, 20, 17, 48, 34]
+        df = pd.DataFrame({"id": cid, "kind": ckind, "sort": csort, "val": cval})
+        return df.set_index("id", drop=False)
+
     def create_one_valued_time_series(self):
         cid = [1, 2, 2]
         ckind = ["a", "a", "a"]

--- a/tests/units/feature_extraction/test_extraction.py
+++ b/tests/units/feature_extraction/test_extraction.py
@@ -145,6 +145,15 @@ class ExtractionTestCase(DataTestCase):
         for col in features_parallel.columns:
             np.testing.assert_array_almost_equal(features_parallel[col], features_serial[col])
 
+    def test_extract_index_preservation(self):
+        df = self.create_test_data_nearly_numerical_indices()
+        extracted_features = extract_features(df, column_id="id", column_sort="sort", column_kind="kind",
+                                              column_value="val",
+                                              n_jobs=self.n_jobs)
+
+        self.assertIsInstance(extracted_features, pd.DataFrame)
+        self.assertTrue(set(df.index) == set(extracted_features.index))
+
 
 class ParallelExtractionTestCase(DataTestCase):
     def setUp(self):

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -234,7 +234,9 @@ def _do_extraction(df, column_id, column_value, column_kind,
     distributor.close()
 
     # Return a dataframe in the typical form (id as index and feature names as columns)
-    result = pd.DataFrame(result, dtype=np.float)
+    result = pd.DataFrame(result)
+    if result.columns.contains("value"):
+        result["value"] = result["value"].astype(float)
 
     if len(result) != 0:
         result = result.pivot("id", "variable", "value")


### PR DESCRIPTION
The added tests show a problem where DataFrame indices are converted to float if they are "nearly" floats. The test case uses indices with the format 99999_9999_99. A small change to fix this. Thanks for the great library.