### PR TITLE
Improve rolling using numpy concatenate

### DIFF
--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -74,9 +74,8 @@ class FeatureCalculationTestCase(TestCase):
                              f(pd.Series(input_to_f), *args, **kwargs), result))
 
     def test__roll(self):
-        np.random.seed(42)
         x = np.random.normal(size=30)
-        for shift in [1, 10, 30, 50, 150]:
+        for shift in [0, 1, 10, 11, 30, 31, 50, 51, 150, 151]:
             np.testing.assert_array_equal(_roll(x,  shift), np.roll(x,  shift))
             np.testing.assert_array_equal(_roll(x, -shift), np.roll(x, -shift))
 

--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -8,6 +8,7 @@ from builtins import range
 from random import shuffle
 from unittest import TestCase
 from tsfresh.feature_extraction.feature_calculators import *
+from tsfresh.feature_extraction.feature_calculators import _roll
 from tsfresh.feature_extraction.feature_calculators import _get_length_sequences_where
 from tsfresh.feature_extraction.feature_calculators import _estimate_friedrich_coefficients
 from tsfresh.feature_extraction.feature_calculators import _aggregate_on_chunks
@@ -71,6 +72,13 @@ class FeatureCalculationTestCase(TestCase):
         self.assertEqual(f(pd.Series(input_to_f), *args, **kwargs), result,
                          msg="Not equal for pandas.Series: %s != %s" % (
                              f(pd.Series(input_to_f), *args, **kwargs), result))
+
+    def test__roll(self):
+        np.random.seed(42)
+        x = np.random.normal(size=30)
+        for shift in [1, 10, 30, 50, 150]:
+            np.testing.assert_array_equal(_roll(x,  shift), np.roll(x,  shift))
+            np.testing.assert_array_equal(_roll(x, -shift), np.roll(x, -shift))
 
     def test___get_length_sequences_where(self):
         self.assertEqualOnAllArrayTypes(_get_length_sequences_where, [0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1],

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -71,6 +71,8 @@ def _roll(a, shift):
     :return: shifted array with the same shape as a
     :return type: ndarray
     """
+    if not isinstance(a, np.ndarray):
+        a = np.asarray(a)
     idx = shift % len(a)
     return np.concatenate([a[-idx:], a[:-idx]])
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -33,7 +33,35 @@ from statsmodels.tsa.stattools import acf, adfuller, pacf
 
 def _roll(a, shift):
     """
-    Roll one-dimensional array elements.
+    Roll 1D array elements. Improves the performance of numpy.roll() by reducing the overhead introduced from the 
+    flexibility of the numpy.roll() method such as the support for rolling over multiple dimensions. 
+    
+    Elements that roll beyond the last position are re-introduced at the beginning. Similarly, elements that roll
+    back beyond the first position are re-introduced at the end (with negative shift).
+    
+    Examples
+    --------
+    >>> x = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    >>> _roll(x, shift=2)
+    >>> array([8, 9, 0, 1, 2, 3, 4, 5, 6, 7])
+    
+    >>> x = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    >>> _roll(x, shift=-2)
+    >>> array([2, 3, 4, 5, 6, 7, 8, 9, 0, 1])
+    
+    >>> x = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    >>> _roll(x, shift=12)
+    >>> array([8, 9, 0, 1, 2, 3, 4, 5, 6, 7])
+    
+    Benchmark
+    ---------
+    >>> x = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    >>> %timeit _roll(x, shift=2)
+    >>> 1.89 µs ± 341 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
+    
+    >>> x = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    >>> %timeit np.roll(x, shift=2)
+    >>> 11.4 µs ± 776 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
     
     :param a: the input array
     :type a: array_like


### PR DESCRIPTION
Changelog:
* Added new `_roll(a, shift)` method which uses `numpy.concatenate()` to reduce the overhead of `numpy.roll()` limiting the use to 1D arrays only.

Benchmark example:

```
%timeit numpy.roll(x, shift=5)
27.2 µs ± 713 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%timeit _roll(x, shift=5)
10.6 µs ± 309 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```