### PR TITLE
Drop support for legacy Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,21 @@ jobs:
       python: 3.5.2
 
     - stage: Run unit tests and deploy
+      env: NUMPY="latest", PANDAS="0.23.4", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
+      before_script:
+        - pip install --upgrade numpy
+        - pip install pandas===0.23.4
+        - pip install --upgrade scikit-learn
+        - pip install --upgrade dask
+        - pip install --upgrade distributed
+        - pip install --upgrade scipy
+        - pip list
+      script:
+        - sed -i 's/\-n auto/\-n 2/g' setup.cfg
+        - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then pytest tests/units -n2; else pytest tests; fi"
+      python: 3.6
+
+    - stage: Run unit tests and deploy
       env: NUMPY="1.10.4", PANDAS="0.20.3", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
       before_script:
         - pip install numpy==1.10.4
@@ -42,6 +57,23 @@ jobs:
         - sed -i 's/\-n auto/\-n 2/g' setup.cfg
         - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then pytest tests/units -n2; else pytest tests; fi"
       python: 3.5.2
+
+    - stage: Run unit tests and deploy
+      env: NUMPY="1.10.4", PANDAS="0.20.3", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
+      before_script:
+        - pip install numpy==1.10.4
+        - pip install pandas==0.20.3
+        - pip install scikit-learn==0.18.0
+        - pip install dask==0.15.2
+        - pip install distributed==1.18.3
+        # need to downgrade tornado manually
+        - pip install tornado==4.5.3
+        - pip install scipy==1.2.0
+        - pip list
+      script:
+        - sed -i 's/\-n auto/\-n 2/g' setup.cfg
+        - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then pytest tests/units -n2; else pytest tests; fi"
+      python: 3.6
 
       deploy:
         provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,42 +23,8 @@ jobs:
         - pip list
       script:
         - sed -i 's/\-n auto/\-n 2/g' setup.cfg
-        - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then py.test tests/units -n2; else python setup.py test; fi"
-      python: 2.7.11
-      after_success:
-        - coveralls
-
-    - stage: Run unit tests and deploy
-      env: NUMPY="latest", PANDAS="0.23.4", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
-      before_script:
-        - pip install --upgrade numpy
-        - pip install pandas===0.23.4
-        - pip install --upgrade scikit-learn
-        - pip install --upgrade dask
-        - pip install --upgrade distributed
-        - pip install --upgrade scipy
-        - pip list
-      script:
-        - sed -i 's/\-n auto/\-n 2/g' setup.cfg
         - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then pytest tests/units -n2; else pytest tests; fi"
       python: 3.5.2
-
-    - stage: Run unit tests and deploy
-      env: NUMPY="1.10.4", PANDAS="0.20.3", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
-      before_script:
-        - pip install numpy==1.10.4
-        - pip install pandas==0.20.3
-        - pip install scikit-learn==0.18.0
-        - pip install dask==0.15.2
-        - pip install distributed==1.18.3
-        # need to downgrade tornado manually
-        - pip install tornado==4.5.3
-        - pip install scipy==1.2.0
-        - pip list
-      script:
-        - sed -i 's/\-n auto/\-n 2/g' setup.cfg
-        - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then pytest tests/units -n2; else pytest tests; fi"
-      python: 2.7.11
 
     - stage: Run unit tests and deploy
       env: NUMPY="1.10.4", PANDAS="0.20.3", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 # Travis Build file for tsfresh
 language: python
-# We do not use sudo here, so we can use docker containers, which have better caching
-sudo: false
 # We want the pip folder to be cached, to speed up installation
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Coverage Status](https://coveralls.io/repos/github/blue-yonder/tsfresh/badge.svg?branch=master)](https://coveralls.io/github/blue-yonder/tsfresh?branch=master)
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/blue-yonder/tsfresh/blob/master/LICENSE.txt)
 [![Gitter chat](https://badges.gitter.im/tsfresh/Lobby.svg)](https://gitter.im/tsfresh/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
-![py27 status](https://img.shields.io/badge/python2.7-supported-green.svg)
 [![py352 status](https://img.shields.io/badge/python3.5.2-supported-green.svg)](https://github.com/blue-yonder/tsfresh/issues/8)
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/blue-yonder/tsfresh/master?filepath=notebooks)
 [![Downloads](https://pepy.tech/badge/tsfresh)](https://pepy.tech/project/tsfresh)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,8 +63,8 @@ master_doc = 'index'
 # General information about the project.
 import datetime
 now = datetime.datetime.today()
-project = u'tsfresh'
-copyright = u'2016-{}, Maximilian Christ et al./ Blue Yonder GmbH'.format(now.year)
+project = 'tsfresh'
+copyright = '2016-{}, Maximilian Christ et al./ Blue Yonder GmbH'.format(now.year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -218,8 +218,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'user_guide.tex', u'tsfresh Documentation',
-   u'', 'manual'),
+  ('index', 'user_guide.tex', 'tsfresh Documentation',
+   '', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/text/faq.rst
+++ b/docs/text/faq.rst
@@ -29,7 +29,7 @@ FAQ
        .. code:: Bash
 
            conda create -n ENV_NAME python=VERSION
-           conda install -n ENV_NAME pip requests numpy pandas scipy statsmodels patsy scikit-learn future six tqdm
+           conda install -n ENV_NAME pip requests numpy pandas scipy statsmodels patsy scikit-learn future tqdm
            activate ENV_NAME
            pip install tsfresh
 

--- a/docs/text/faq.rst
+++ b/docs/text/faq.rst
@@ -29,7 +29,7 @@ FAQ
        .. code:: Bash
 
            conda create -n ENV_NAME python=VERSION
-           conda install -n ENV_NAME pip requests numpy pandas scipy statsmodels patsy scikit-learn future tqdm
+           conda install -n ENV_NAME pip requests numpy pandas scipy statsmodels patsy scikit-learn tqdm
            activate ENV_NAME
            pip install tsfresh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,7 @@ pandas>=0.20.3,<=0.23.4 # pandas dropna is buggy in 0.24.0, see https://github.c
 scipy>=1.2.0
 statsmodels>=0.8.0
 patsy>=0.4.1
-scikit-learn>=0.19.0,<0.21.0; python_version <= '2.7'
-scikit-learn>=0.19.0; python_version > '3'
-future>=0.16.0
-six>=1.10.0
+scikit-learn>=0.19.0
 tqdm>=4.10.0
-ipaddress>=1.0.18; python_version <= '2.7'
 dask>=0.15.2
 distributed>=1.18.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,18 +10,20 @@ home-page = https://github.com/blue-yonder/tsfresh
 classifier =
     Development Status :: 4 - Beta
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3 :: Only
     Operating System :: Unix
     Operating System :: Microsoft :: Windows
     Operating System :: MacOS
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering
     Topic :: Software Development
+
+[options]
+python_requires = >= 3.5
 
 [entry_points]
 # Add here console scripts like:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     use_scm_version=True,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    setup_requires=["six", "setuptools_scm"] + sphinx,
+    setup_requires=["setuptools_scm"] + sphinx,
     packages=find_packages(),
     install_requires=requirements,
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,6 @@
 pytest>=4.0.0
 pytest-cov>=2.3.1
 pytest-xdist>=1.25.0
-six>=1.10.0
 mock>=2.0.0
 matplotlib>=2.0.0
 seaborn>=0.7.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
-# test suite fails on pytest 3.8.0 and above with internal error
-pytest>=4.0.0
-pytest-cov>=2.3.1
-pytest-xdist>=1.25.0
+pytest>=4.2.0
+pytest-cov>=2.6.1
+pytest-xdist>=1.26.1
 mock>=2.0.0
 matplotlib>=2.0.0
 seaborn>=0.7.1

--- a/tests/integrations/examples/test_driftbif_simulation.py
+++ b/tests/integrations/examples/test_driftbif_simulation.py
@@ -65,8 +65,8 @@ class DriftBifSimlationTestCase(unittest.TestCase):
 class SampleTauTestCase(unittest.TestCase):
     def test_range(self):
         tau = sample_tau(100)
-        self.assertTrue(min(tau) >= 2.87)
-        self.assertTrue(max(tau) <= 3.8)
+        self.assertGreaterEqual(min(tau), 2.87)
+        self.assertLessEqual(max(tau), 3.8)
 
     def test_ratio(self):
         tau = sample_tau(100000, ratio=0.4)

--- a/tests/integrations/examples/test_driftbif_simulation.py
+++ b/tests/integrations/examples/test_driftbif_simulation.py
@@ -79,7 +79,7 @@ class SampleTauTestCase(unittest.TestCase):
 class LoadDriftBifTestCase(unittest.TestCase):
     def test_classification_labels(self):
         X, y = load_driftbif(10, 100)
-        self.assertEqual(set(y), set([0, 1]))
+        self.assertEqual(set(y), {0, 1})
 
     def test_regression_labels(self):
         Nsamples = 10

--- a/tests/integrations/examples/test_har_dataset.py
+++ b/tests/integrations/examples/test_har_dataset.py
@@ -21,4 +21,4 @@ class HumanActivityTestCase(TestCase):
         self.assertIsInstance(self.classes, Series)
 
     def test_index(self):
-        six.assertCountEqual(self, self.data.index, self.classes.index)
+        self.assertCountEqual(self.data.index, self.classes.index)

--- a/tests/integrations/examples/test_har_dataset.py
+++ b/tests/integrations/examples/test_har_dataset.py
@@ -5,7 +5,6 @@
 from unittest import TestCase
 from tsfresh.examples.har_dataset import download_har_dataset, load_har_dataset, load_har_classes
 from pandas import DataFrame, Series
-import six
 
 class HumanActivityTestCase(TestCase):
     def setUp(self):

--- a/tests/integrations/examples/test_robot_execution_failures.py
+++ b/tests/integrations/examples/test_robot_execution_failures.py
@@ -7,7 +7,6 @@ from unittest import TestCase
 from tsfresh import extract_features
 from tsfresh.examples.robot_execution_failures import load_robot_execution_failures, download_robot_execution_failures
 from pandas import DataFrame, Series
-import six
 import numpy as np
 
 

--- a/tests/integrations/examples/test_robot_execution_failures.py
+++ b/tests/integrations/examples/test_robot_execution_failures.py
@@ -20,12 +20,12 @@ class RobotExecutionFailuresTestCase(TestCase):
         self.assertEqual(len(self.X), 1320)
         self.assertIsInstance(self.X, DataFrame)
         self.assertIsInstance(self.y, Series)
-        six.assertCountEqual(self, ['id', 'time', 'F_x', 'F_y', 'F_z', 'T_x', 'T_y', 'T_z'], list(self.X.columns))
+        self.assertCountEqual(['id', 'time', 'F_x', 'F_y', 'F_z', 'T_x', 'T_y', 'T_z'], list(self.X.columns))
 
     def test_extraction_runs_through(self):
         df = extract_features(self.X[self.X.id < 3], column_id="id", column_sort="time")
 
-        six.assertCountEqual(self, df.index.values, [1, 2])
+        self.assertCountEqual(df.index.values, [1, 2])
         self.assertGreater(len(df), 0)
 
     def test_binary_target_is_default(self):

--- a/tests/integrations/test_notebooks.py
+++ b/tests/integrations/test_notebooks.py
@@ -6,7 +6,6 @@ import os
 import subprocess
 import tempfile
 import nbformat
-import six
 
 from unittest import TestCase
 
@@ -40,10 +39,7 @@ def _notebook_run(path, timeout=default_timeout):
         
         args = ["jupyter", "nbconvert",
                 "--to", "notebook", "--execute", execproc_timeout]
-        if six.PY2:
-            args += ["--ExecutePreprocessor.kernel_name=python2"]
-        elif six.PY3:
-            args += ["--ExecutePreprocessor.kernel_name=python3"]
+        args += ["--ExecutePreprocessor.kernel_name=python3"]
         args += ["--output", fout.name, path]
         subprocess.check_call(args)
 

--- a/tests/integrations/test_relevant_feature_extraction.py
+++ b/tests/integrations/test_relevant_feature_extraction.py
@@ -2,7 +2,6 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
-from __future__ import absolute_import, division
 from tests.fixtures import DataTestCase
 from tsfresh import extract_features, select_features, extract_relevant_features
 from tsfresh.feature_extraction.settings import ComprehensiveFCParameters

--- a/tests/units/feature_extraction/test_extraction.py
+++ b/tests/units/feature_extraction/test_extraction.py
@@ -2,8 +2,6 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
-from __future__ import absolute_import, division
-
 import os
 import tempfile
 

--- a/tests/units/feature_extraction/test_extraction.py
+++ b/tests/units/feature_extraction/test_extraction.py
@@ -9,7 +9,6 @@ import tempfile
 
 import numpy as np
 import pandas as pd
-import six
 from mock import Mock
 
 from tests.fixtures import DataTestCase

--- a/tests/units/feature_extraction/test_extraction.py
+++ b/tests/units/feature_extraction/test_extraction.py
@@ -188,7 +188,7 @@ class ExtractionTestCase(DataTestCase):
                                               n_jobs=self.n_jobs)
 
         self.assertIsInstance(extracted_features, pd.DataFrame)
-        self.assertTrue(set(df["id"]) == set(extracted_features.index))
+        self.assertEqual(set(df["id"]), set(extracted_features.index))
 
 
 class ParallelExtractionTestCase(DataTestCase):

--- a/tests/units/feature_extraction/test_extraction.py
+++ b/tests/units/feature_extraction/test_extraction.py
@@ -128,8 +128,8 @@ class ExtractionTestCase(DataTestCase):
                                                           column_value="val",
                                                           n_jobs=self.n_jobs).sort_index()
 
-        six.assertCountEqual(self, extracted_features.columns,
-                             extracted_features_from_random.columns)
+        self.assertCountEqual(extracted_features.columns,
+                              extracted_features_from_random.columns)
 
         for col in extracted_features:
             self.assertIsNone(np.testing.assert_array_almost_equal(extracted_features[col],
@@ -179,7 +179,7 @@ class ExtractionTestCase(DataTestCase):
                                            column_kind="kind", column_value="val",
                                            n_jobs=0)
 
-        six.assertCountEqual(self, features_parallel.columns, features_serial.columns)
+        self.assertCountEqual(features_parallel.columns, features_serial.columns)
 
         for col in features_parallel.columns:
             np.testing.assert_array_almost_equal(features_parallel[col], features_serial[col])

--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -12,7 +12,6 @@ from tsfresh.feature_extraction.feature_calculators import _get_length_sequences
 from tsfresh.feature_extraction.feature_calculators import _estimate_friedrich_coefficients
 from tsfresh.feature_extraction.feature_calculators import _aggregate_on_chunks
 from tsfresh.examples.driftbif_simulation import velocity
-import six
 import math
 
 

--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -865,13 +865,13 @@ class FeatureCalculationTestCase(TestCase):
         ds = velocity(tau=3.8, delta_t=0.05, R=3e-4, seed=0)
         v = ds.simulate(100000, v0=np.zeros(1))
         v0 = max_langevin_fixed_point(v[:, 0], **default_params)
-        self.assertTrue(abs(ds.deterministic - v0) < 0.001)
+        self.assertLess(abs(ds.deterministic - v0), 0.001)
 
         # Brownian motion
         ds = velocity(tau=2.0 / 0.3 - 3.8, delta_t=0.05, R=3e-4, seed=0)
         v = ds.simulate(10000, v0=np.zeros(1))
         v0 = max_langevin_fixed_point(v[:, 0], **default_params)
-        self.assertTrue(v0 < 0.001)
+        self.assertLess(v0, 0.001)
 
     def test_linear_trend(self):
         # check linear up trend
@@ -1127,13 +1127,13 @@ class FriedrichTestCase(TestCase):
         ds = velocity(tau=3.8, delta_t=0.05, R=3e-4, seed=0)
         v = ds.simulate(10000, v0=np.zeros(1))
         coeff = _estimate_friedrich_coefficients(v[:, 0], **default_params)
-        self.assertTrue(abs(coeff[-1]) < 0.0001)
+        self.assertLess(abs(coeff[-1]), 0.0001)
 
         # Brownian motion
         ds = velocity(tau=2.0 / 0.3 - 3.8, delta_t=0.05, R=3e-4, seed=0)
         v = ds.simulate(10000, v0=np.zeros(1))
         coeff = _estimate_friedrich_coefficients(v[:, 0], **default_params)
-        self.assertTrue(abs(coeff[-1]) < 0.0001)
+        self.assertLess(abs(coeff[-1]), 0.0001)
 
     def test_friedrich_coefficients(self):
         # Test binning error returns vector of NaNs

--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -23,12 +23,12 @@ class FeatureCalculationTestCase(TestCase):
 
     def assertEqualOnAllArrayTypes(self, f, input_to_f, result, *args, **kwargs):
         self.assertEqual(f(input_to_f, *args, **kwargs), result,
-                         msg="Not equal for lists: %s != %s" % (f(input_to_f, *args, **kwargs), result))
+                         msg="Not equal for lists: {} != {}".format(f(input_to_f, *args, **kwargs), result))
         self.assertEqual(f(np.array(input_to_f), *args, **kwargs), result,
-                         msg="Not equal for numpy.arrays: %s != %s" % (
+                         msg="Not equal for numpy.arrays: {} != {}".format(
                          f(np.array(input_to_f), *args, **kwargs), result))
         self.assertEqual(f(pd.Series(input_to_f), *args, **kwargs), result,
-                         msg="Not equal for pandas.Series: %s != %s" % (
+                         msg="Not equal for pandas.Series: {} != {}".format(
                          f(pd.Series(input_to_f), *args, **kwargs), result))
 
     def assertTrueOnAllArrayTypes(self, f, input_to_f, *args, **kwargs):
@@ -53,12 +53,12 @@ class FeatureCalculationTestCase(TestCase):
 
     def assertAlmostEqualOnAllArrayTypes(self, f, input_t_f, result, *args, **kwargs):
         self.assertAlmostEqual(f(input_t_f, *args, **kwargs), result,
-                               msg="Not almost equal for lists: %s != %s" % (f(input_t_f, *args, **kwargs), result))
+                               msg="Not almost equal for lists: {} != {}".format(f(input_t_f, *args, **kwargs), result))
         self.assertAlmostEqual(f(np.array(input_t_f), *args, **kwargs), result,
-                               msg="Not almost equal for np.arrays: %s != %s" % (
+                               msg="Not almost equal for np.arrays: {} != {}".format(
                                    f(np.array(input_t_f), *args, **kwargs), result))
         self.assertAlmostEqual(f(pd.Series(input_t_f), *args, **kwargs), result,
-                               msg="Not almost equal for pd.Series: %s != %s" % (
+                               msg="Not almost equal for pd.Series: {} != {}".format(
                                    f(pd.Series(input_t_f), *args, **kwargs), result))
 
     def assertIsNanOnAllArrayTypes(self, f, input_to_f, *args, **kwargs):
@@ -68,7 +68,7 @@ class FeatureCalculationTestCase(TestCase):
 
     def assertEqualPandasSeriesWrapper(self, f, input_to_f, result, *args, **kwargs):
         self.assertEqual(f(pd.Series(input_to_f), *args, **kwargs), result,
-                         msg="Not equal for pandas.Series: %s != %s" % (
+                         msg="Not equal for pandas.Series: {} != {}".format(
                              f(pd.Series(input_to_f), *args, **kwargs), result))
 
     def test__roll(self):
@@ -258,7 +258,7 @@ class FeatureCalculationTestCase(TestCase):
 
         res = augmented_dickey_fuller(x=x, param=param)
         res = pd.Series(dict(res))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertGreater(res['attr_"pvalue"'], 0.10)
         self.assertEqual(res['attr_"usedlag"'], 0)
 
@@ -275,7 +275,7 @@ class FeatureCalculationTestCase(TestCase):
 
         res = augmented_dickey_fuller(x=x, param=param)
         res = pd.Series(dict(res))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertLessEqual(res['attr_"pvalue"'], 0.05)
         self.assertEqual(res['attr_"usedlag"'], 0)
 
@@ -475,7 +475,7 @@ class FeatureCalculationTestCase(TestCase):
                           'coeff_0__attr_"abs"', 'coeff_1__attr_"abs"', 'coeff_2__attr_"abs"']
 
         res = pd.Series(dict(fft_coefficient(x, param)))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res['coeff_0__attr_"imag"'], 0, places=6)
         self.assertAlmostEqual(res['coeff_0__attr_"real"'], sum(x), places=6)
         self.assertAlmostEqual(res['coeff_0__attr_"angle"'], 0, places=6)
@@ -499,7 +499,7 @@ class FeatureCalculationTestCase(TestCase):
         expected_index = ['coeff_10__attr_"real"']
 
         res = pd.Series(dict(fft_coefficient(x, param)))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertIsNaN(res['coeff_10__attr_"real"'])
 
     def test_fft_aggregated(self):
@@ -513,7 +513,7 @@ class FeatureCalculationTestCase(TestCase):
 
         x = np.arange(10)
         res = pd.Series(dict(fft_aggregated(x, param)))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res['aggtype_"centroid"'], 1.135, places=3)
         self.assertAlmostEqual(res['aggtype_"variance"'], 2.368, places=3)
         self.assertAlmostEqual(res['aggtype_"skew"'], 1.249, places=3)
@@ -522,7 +522,7 @@ class FeatureCalculationTestCase(TestCase):
         # Scalar multiplying the distribution should not change the results:
         x = 10*x
         res = pd.Series(dict(fft_aggregated(x, param)))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res['aggtype_"centroid"'], 1.135, places=3)
         self.assertAlmostEqual(res['aggtype_"variance"'], 2.368, places=3)
         self.assertAlmostEqual(res['aggtype_"skew"'], 1.249, places=3)
@@ -533,7 +533,7 @@ class FeatureCalculationTestCase(TestCase):
         # therefore bad features, therefore an nan should be returned for these values
         x = np.sin(2 * np.pi / 10 * np.arange(30))
         res = pd.Series(dict(fft_aggregated(x, param)))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res['aggtype_"centroid"'], 3., places=5)
         self.assertAlmostEqual(res['aggtype_"variance"'], 0., places=5)
         self.assertIsNaN(res['aggtype_"skew"'])
@@ -553,7 +553,7 @@ class FeatureCalculationTestCase(TestCase):
 
         # Calculate values for unit test:
         res = pd.Series(dict(fft_aggregated(x, param)))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
 
         # Compare against hand calculated values:
         rel_diff_allowed = 0.02
@@ -583,7 +583,7 @@ class FeatureCalculationTestCase(TestCase):
         res = index_mass_quantile(x, param)
 
         res = pd.Series(dict(res))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["q_0.5"], 0.5, places=1)
 
         # Test for parts of pandas series
@@ -593,7 +593,7 @@ class FeatureCalculationTestCase(TestCase):
         res = index_mass_quantile(x[x > 0], param)
 
         res = pd.Series(dict(res))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["q_0.5"], 0.5, places=1)
 
         x = [0] * 1000 + [1]
@@ -602,7 +602,7 @@ class FeatureCalculationTestCase(TestCase):
         res = index_mass_quantile(x, param)
 
         res = pd.Series(dict(res))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["q_0.5"], 1, places=1)
         self.assertAlmostEqual(res["q_0.99"], 1, places=1)
 
@@ -614,7 +614,7 @@ class FeatureCalculationTestCase(TestCase):
 
         res = pd.Series(dict(res))
 
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["q_0.3"], 0.25, places=1)
         self.assertAlmostEqual(res["q_0.6"], 0.375, places=1)
         self.assertAlmostEqual(res["q_0.9"], 0.75, places=1)
@@ -625,7 +625,7 @@ class FeatureCalculationTestCase(TestCase):
         res = index_mass_quantile(x, param)
 
         res = pd.Series(dict(res))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertTrue(np.isnan(res["q_0.5"]))
 
         x = []
@@ -634,7 +634,7 @@ class FeatureCalculationTestCase(TestCase):
         res = index_mass_quantile(x, param)
 
         res = pd.Series(dict(res))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertTrue(np.isnan(res["q_0.5"]))
 
     def test_number_cwt_peaks(self):
@@ -648,7 +648,7 @@ class FeatureCalculationTestCase(TestCase):
         param = [{"coeff": 1}, {"coeff": 10}]
         expected_index = ["coeff_1", "coeff_10"]
         res = pd.Series(dict(spkt_welch_density(x, param)))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertIsNaN(res["coeff_10"])
 
     def test_cwt_coefficients(self):
@@ -666,7 +666,7 @@ class FeatureCalculationTestCase(TestCase):
         res = pd.Series(dict(res))
 
         # todo: add unit test for the values
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertTrue(math.isnan(res["widths_(1, 3)__coeff_5__w_3"]))
 
     def test_ar_coefficient(self):
@@ -683,7 +683,7 @@ class FeatureCalculationTestCase(TestCase):
         expected_index = ["k_1__coeff_0", "k_1__coeff_1"]
 
         res = pd.Series(dict(res))
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["k_1__coeff_0"], 1, places=2)
         self.assertAlmostEqual(res["k_1__coeff_1"], 2.5, places=2)
 
@@ -704,7 +704,7 @@ class FeatureCalculationTestCase(TestCase):
         res = pd.Series(dict(res))
 
         self.assertIsInstance(res, pd.Series)
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["k_2__coeff_0"], 1, places=2)
         self.assertAlmostEqual(res["k_2__coeff_1"], 3.5, places=2)
         self.assertAlmostEqual(res["k_2__coeff_2"], -2, places=2)
@@ -890,7 +890,7 @@ class FeatureCalculationTestCase(TestCase):
                           "attr_\"stderr\""]
 
         self.assertEqual(len(res), 5)
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["attr_\"pvalue\""], 0)
         self.assertAlmostEqual(res["attr_\"stderr\""], 0)
         self.assertAlmostEqual(res["attr_\"intercept\""], 0)
@@ -958,7 +958,7 @@ class FeatureCalculationTestCase(TestCase):
         res = pd.Series(dict(res))
         self.assertEqual(len(res), 8)
         self.maxDiff = 2000
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res['f_agg_"max"__chunk_len_3__attr_"intercept"'], 2)
         self.assertAlmostEqual(res['f_agg_"max"__chunk_len_3__attr_"slope"'], 3)
         self.assertAlmostEqual(res['f_agg_"min"__chunk_len_3__attr_"intercept"'], 0)
@@ -1048,7 +1048,7 @@ class FeatureCalculationTestCase(TestCase):
                           "attr_\"stderr\""]
 
         self.assertEqual(len(res), 5)
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertAlmostEqual(res["attr_\"pvalue\""], 0, places=3)
         self.assertAlmostEqual(res["attr_\"stderr\""], 0, places=3)
         self.assertAlmostEqual(res["attr_\"intercept\""], 0, places=3)
@@ -1145,7 +1145,7 @@ class FriedrichTestCase(TestCase):
         res = pd.Series(dict(friedrich_coefficients(x, param)))
 
         expected_index = ["m_2__r_30__coeff_0", "m_2__r_30__coeff_1", "m_2__r_30__coeff_2", "m_2__r_30__coeff_3"]
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertTrue(np.sum(np.isnan(res)), 3)
 
     def test_friedrich_number_of_returned_features_is_equal_to_number_of_parameters(self):
@@ -1155,7 +1155,7 @@ class FriedrichTestCase(TestCase):
         res = pd.Series(dict(friedrich_coefficients(x, param)))
 
         expected_index = ["m_3__r_5__coeff_2", "m_3__r_5__coeff_3", "m_3__r_2__coeff_3"]
-        six.assertCountEqual(self, list(res.index), expected_index)
+        self.assertCountEqual(list(res.index), expected_index)
         self.assertTrue(np.sum(np.isnan(res)), 3)
 
     def test_friedrich_equal_to_snapshot(self):

--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -2,8 +2,6 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
-from __future__ import absolute_import, division
-from __future__ import print_function
 from random import shuffle
 from unittest import TestCase
 from tsfresh.feature_extraction.feature_calculators import *

--- a/tests/units/feature_extraction/test_settings.py
+++ b/tests/units/feature_extraction/test_settings.py
@@ -44,7 +44,7 @@ class TestSettingsObject(TestCase):
                              ["sum_values", "median", "length", "sample_entropy", "quantile", "number_peaks",
                               "ar_coefficient", "value_count"])
 
-        self.assertEqual(kind_to_fc_parameters[tsn]["sum_values"], None)
+        self.assertIsNone(kind_to_fc_parameters[tsn]["sum_values"])
         self.assertEqual(kind_to_fc_parameters[tsn]["ar_coefficient"],
                          [{"k": 20, "coeff": 4}, {"k": -1, "coeff": 10}])
 

--- a/tests/units/feature_extraction/test_settings.py
+++ b/tests/units/feature_extraction/test_settings.py
@@ -10,7 +10,6 @@ import pandas as pd
 from tsfresh.feature_extraction.extraction import extract_features
 from tsfresh.feature_extraction.settings import ComprehensiveFCParameters, MinimalFCParameters, \
     EfficientFCParameters, from_columns, TimeBasedFCParameters, IndexBasedFCParameters
-import six
 from tsfresh.feature_extraction import feature_calculators
 from pandas.testing import assert_frame_equal
 

--- a/tests/units/feature_extraction/test_settings.py
+++ b/tests/units/feature_extraction/test_settings.py
@@ -43,7 +43,7 @@ class TestSettingsObject(TestCase):
         feature_names += [tsn + '__ar_coefficient__k_20__coeff_4', tsn + '__ar_coefficient__coeff_10__k_-1']
 
         kind_to_fc_parameters = from_columns(feature_names)
-        six.assertCountEqual(self, list(kind_to_fc_parameters[tsn].keys()),
+        self.assertCountEqual(list(kind_to_fc_parameters[tsn].keys()),
                              ["sum_values", "median", "length", "sample_entropy", "quantile", "number_peaks",
                               "ar_coefficient", "value_count"])
 
@@ -76,7 +76,7 @@ class TestSettingsObject(TestCase):
         kind_to_fc_parameters = from_columns(feature_names, columns_to_ignore=["THIS_COL_SHOULD_BE_IGNORED",
                                                                                "THIS_AS_WELL"])
 
-        six.assertCountEqual(self, list(kind_to_fc_parameters[tsn].keys()),
+        self.assertCountEqual(list(kind_to_fc_parameters[tsn].keys()),
                              ["sum_values", "median", "length", "sample_entropy"])
 
     def test_default_calculates_all_features(self):
@@ -127,7 +127,7 @@ class TestEfficientFCParameters(TestCase):
                                               column_kind="kind", column_value="value",
                                               column_sort="time", column_id="id")
 
-        six.assertCountEqual(self, extracted_features.index, [0, 1])
+        self.assertCountEqual(extracted_features.index, [0, 1])
 
     def test_contains_all_non_high_comp_cost_features(self):
         """
@@ -197,7 +197,7 @@ class TestMinimalSettingsObject(TestCase):
                                               column_kind="kind", column_value="value",
                                               column_sort="time", column_id="id")
 
-        six.assertCountEqual(self, extracted_features.columns, ["0__median", "0__standard_deviation", "0__sum_values",
+        self.assertCountEqual(extracted_features.columns, ["0__median", "0__standard_deviation", "0__sum_values",
                                                                 "0__maximum", "0__variance", "0__minimum", "0__mean",
                                                                 "0__length"])
-        six.assertCountEqual(self, extracted_features.index, [0, 1])
+        self.assertCountEqual(extracted_features.index, [0, 1])

--- a/tests/units/feature_extraction/test_settings.py
+++ b/tests/units/feature_extraction/test_settings.py
@@ -2,8 +2,6 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
-from __future__ import absolute_import, division
-
 from unittest import TestCase
 import numpy as np
 import pandas as pd

--- a/tests/units/feature_selection/test_feature_significance.py
+++ b/tests/units/feature_selection/test_feature_significance.py
@@ -69,7 +69,7 @@ class FeatureSignificanceTestCase(TestCase):
             else:
                 self.assertEqual(row.type, "binary")
 
-            self.assertEqual(row.relevant, False)
+            self.assertFalse(row.relevant)
 
             # Assert that all of the relevant features are kept.
             # THIS FAILS!
@@ -131,7 +131,7 @@ class FeatureSignificanceTestCase(TestCase):
             self.assertEqual(row.feature, "irr{}".format(i))
             self.assertEqual(row.type, "binary")
 
-            self.assertEqual(row.relevant, False)
+            self.assertFalse(row.relevant)
 
     def test_binomial_target_realvalued_features(self):
         # Real valued random variables and binomial target
@@ -172,7 +172,7 @@ class FeatureSignificanceTestCase(TestCase):
             self.assertEqual(row.feature, "irr{}".format(i))
             self.assertEqual(row.type, "real")
 
-            self.assertEqual(row.relevant, False)
+            self.assertFalse(row.relevant)
 
     def test_real_target_mixed_case(self):
         # Mixed case with real target
@@ -224,7 +224,7 @@ class FeatureSignificanceTestCase(TestCase):
             else:
                 self.assertEqual(row.type, "real")
 
-            self.assertEqual(row.relevant, False)
+            self.assertFalse(row.relevant)
 
     def test_real_target_binary_features(self):
         # Mixed case with real target

--- a/tests/units/scripts/test_run_tsfresh.py
+++ b/tests/units/scripts/test_run_tsfresh.py
@@ -85,7 +85,7 @@ class RunTSFreshTestCase(TestCase):
 
         self.assertEqual(called_kwargs["column_id"], "id")
         self.assertEqual(called_kwargs["column_value"], "value")
-        self.assertEqual(called_kwargs["column_kind"], None)
+        self.assertIsNone(called_kwargs["column_kind"])
         self.assertEqual(called_kwargs["column_sort"], "time")
 
     def test_csv_with_header(self):

--- a/tests/units/transformers/test_feature_augmenter.py
+++ b/tests/units/transformers/test_feature_augmenter.py
@@ -27,7 +27,7 @@ class FeatureAugmenterTestCase(DataTestCase):
 
         # Fit should do nothing
         returned_df = augmenter.fit()
-        six.assertCountEqual(self, returned_df.__dict__, augmenter.__dict__)
+        self.assertCountEqual(returned_df.__dict__, augmenter.__dict__)
         self.assertRaises(RuntimeError, augmenter.transform, None)
 
         augmenter.set_timeseries_container(self.test_df)
@@ -46,7 +46,7 @@ class FeatureAugmenterTestCase(DataTestCase):
         self.assertEqual(X_transformed.shape, (2, 3))
 
         # Preserve old features
-        six.assertCountEqual(self, list(X_transformed.columns), ["feature_1", "a__length", "b__length"])
+        self.assertCountEqual(list(X_transformed.columns), ["feature_1", "a__length", "b__length"])
 
         # Features are not allowed to be NaN
         for index, row in X_transformed.iterrows():

--- a/tests/units/transformers/test_feature_augmenter.py
+++ b/tests/units/transformers/test_feature_augmenter.py
@@ -7,7 +7,6 @@ import pandas as pd
 from tests.fixtures import DataTestCase
 from tsfresh.feature_extraction.settings import ComprehensiveFCParameters
 from tsfresh.transformers import FeatureAugmenter
-import six
 import numpy as np
 
 class FeatureAugmenterTestCase(DataTestCase):

--- a/tests/units/transformers/test_feature_augmenter.py
+++ b/tests/units/transformers/test_feature_augmenter.py
@@ -2,7 +2,6 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
-from __future__ import print_function
 import pandas as pd
 from tests.fixtures import DataTestCase
 from tsfresh.feature_extraction.settings import ComprehensiveFCParameters

--- a/tests/units/transformers/test_feature_selector.py
+++ b/tests/units/transformers/test_feature_selector.py
@@ -101,7 +101,7 @@ class FeatureSelectorTestCase(TestCase):
         
     def test_feature_importance(self):
         selector = FeatureSelector()
-        self.assertTrue(selector.feature_importances_ is None)
+        self.assertIsNone(selector.feature_importances_)
         
         y = pd.Series(np.random.binomial(1, 0.5, 1000))
         X = pd.DataFrame(index=list(range(1000)))
@@ -115,7 +115,7 @@ class FeatureSelectorTestCase(TestCase):
 
     def test_feature_importance(self):
         selector = FeatureSelector()
-        self.assertTrue(selector.p_values is None)
+        self.assertIsNone(selector.p_values)
         
         y = pd.Series(np.random.binomial(1, 0.5, 1000))
         X = pd.DataFrame(index=list(range(1000)))

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -7,7 +7,6 @@ from unittest import TestCase
 import pandas as pd
 from tsfresh.utilities import dataframe_functions
 import numpy as np
-import six
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 from tsfresh.utilities.dataframe_functions import get_ids

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -68,7 +68,7 @@ class NormalizeTestCase(TestCase):
         self.assertEqual(column_value, "value")
         self.assertEqual(column_kind, "kind")
         self.assertIn("a", set(result_df[column_kind]))
-        six.assertCountEqual(self, list(result_df.columns), ["id", "value", "kind"])
+        self.assertCountEqual(list(result_df.columns), ["id", "value", "kind"])
         self.assertEqual(list(result_df[result_df[column_kind] == "a"]["value"]), [3])
         self.assertEqual(list(result_df[result_df[column_kind] == "a"]["id"]), [0])
 
@@ -82,7 +82,7 @@ class NormalizeTestCase(TestCase):
         self.assertEqual(column_value, "value")
         self.assertEqual(column_kind, "_variables")
         self.assertIn("value", set(result_df[column_kind]))
-        six.assertCountEqual(self, list(result_df.columns), ["id", "value", "_variables"])
+        self.assertCountEqual(list(result_df.columns), ["id", "value", "_variables"])
         self.assertEqual(list(result_df[result_df[column_kind] == "value"]["value"]), [3])
         self.assertEqual(list(result_df[result_df[column_kind] == "value"]["id"]), [0])
 
@@ -97,7 +97,7 @@ class NormalizeTestCase(TestCase):
         self.assertEqual(column_kind, "_variables")
         self.assertIn("a", set(result_df[column_kind]))
         self.assertIn("b", set(result_df[column_kind]))
-        six.assertCountEqual(self, list(result_df.columns), ["_values", "_variables", "id"])
+        self.assertCountEqual(list(result_df.columns), ["_values", "_variables", "id"])
         self.assertEqual(list(result_df[result_df[column_kind] == "a"]["_values"]), [3])
         self.assertEqual(list(result_df[result_df[column_kind] == "a"]["id"]), [0])
         self.assertEqual(list(result_df[result_df[column_kind] == "b"]["_values"]), [5])
@@ -698,9 +698,9 @@ class GetIDsTestCase(TestCase):
 
     def test_get_id__correct_DataFrame(self):
         df = pd.DataFrame({"_value": [1, 2, 3, 4, 10, 11], "id": [1, 1, 1, 1, 2, 2]})
-        self.assertEqual(get_ids(df, "id"), set([1, 2]))
+        self.assertEqual(get_ids(df, "id"), {1, 2})
 
     def test_get_id__correct_dict(self):
         df_dict = {"a": pd.DataFrame({"_value": [1, 2, 3, 4, 10, 11], "id": [1, 1, 1, 1, 2, 2]}),
                    "b": pd.DataFrame({"_value": [5, 6, 7, 8, 12, 13], "id": [4, 4, 3, 3, 2, 2]})}
-        self.assertEqual(get_ids(df_dict, "id"), set([1, 2, 3, 4]))
+        self.assertEqual(get_ids(df_dict, "id"), {1, 2, 3, 4})

--- a/tests/units/utilities/test_string_manipilations.py
+++ b/tests/units/utilities/test_string_manipilations.py
@@ -2,7 +2,6 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
-from __future__ import print_function
 from tsfresh.utilities.string_manipulation import convert_to_output_format
 
 

--- a/tsfresh/__init__.py
+++ b/tsfresh/__init__.py
@@ -20,12 +20,7 @@ except:
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging
-try:  # Python 2.7+
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
+from logging import NullHandler
 
 logging.getLogger(__name__).addHandler(NullHandler())
 

--- a/tsfresh/convenience/relevant_extraction.py
+++ b/tsfresh/convenience/relevant_extraction.py
@@ -2,7 +2,6 @@
 # This file as well as the whole tsfresh package are licenced under the MIT licence (see the LICENCE.txt)
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
-from __future__ import absolute_import
 import pandas as pd
 from tsfresh.feature_extraction import extract_features
 from tsfresh import defaults

--- a/tsfresh/examples/__init__.py
+++ b/tsfresh/examples/__init__.py
@@ -3,7 +3,6 @@ Module with exemplary data sets to play around with.
 
 See for eample the :ref:`quick-start-label` section on how to use them.
 """
-from __future__ import absolute_import
 from .robot_execution_failures import load_robot_execution_failures, download_robot_execution_failures
 from .har_dataset import download_har_dataset, load_har_classes, load_har_dataset
 from .driftbif_simulation import load_driftbif

--- a/tsfresh/examples/driftbif_simulation.py
+++ b/tsfresh/examples/driftbif_simulation.py
@@ -11,12 +11,12 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-class velocity(object):
+class velocity:
     """
     Simulates the velocity of a dissipative soliton (kind of self organized particle) [6]_.
     The equilibrium velocity without noise R=0 for
-    $\tau>1.0/\kappa_3$ is $\kappa_3 \sqrt{(tau - 1.0/\kappa_3)/Q}.
-    Before the drift-bifurcation $\tau \le 1.0/\kappa_3$ the velocity is zero.
+    $\tau>1.0/\\kappa_3$ is $\\kappa_3 \\sqrt{(tau - 1.0/\\kappa_3)/Q}.
+    Before the drift-bifurcation $\tau \\le 1.0/\\kappa_3$ the velocity is zero.
 
     References
     ----------

--- a/tsfresh/examples/har_dataset.py
+++ b/tsfresh/examples/har_dataset.py
@@ -18,7 +18,6 @@ References
 
 """
 
-from __future__ import absolute_import, division
 from io import BytesIO
 from urllib.request import urlopen
 from zipfile import ZipFile

--- a/tsfresh/examples/har_dataset.py
+++ b/tsfresh/examples/har_dataset.py
@@ -61,14 +61,14 @@ def download_har_dataset():
 def load_har_dataset():
     try:
         return pd.read_csv(data_file_name_dataset, delim_whitespace=True, header=None)
-    except IOError:
-        raise IOError('File {} was not found. Have you downloaded the dataset with download_har_dataset() '
+    except OSError:
+        raise OSError('File {} was not found. Have you downloaded the dataset with download_har_dataset() '
                       'before?'.format(data_file_name_dataset))
 
 
 def load_har_classes():
     try:
         return pd.read_csv(data_file_name_classes, delim_whitespace=True, header=None, squeeze=True)
-    except IOError:
-        raise IOError('File {} was not found. Have you downloaded the dataset with download_har_dataset() '
+    except OSError:
+        raise OSError('File {} was not found. Have you downloaded the dataset with download_har_dataset() '
                       'before?'.format(data_file_name_classes))

--- a/tsfresh/examples/robot_execution_failures.py
+++ b/tsfresh/examples/robot_execution_failures.py
@@ -21,8 +21,6 @@ References
 
 """
 
-from __future__ import absolute_import, division
-
 from builtins import map
 import os
 import pandas as pd

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -5,8 +5,6 @@
 This module contains the main function to interact with tsfresh: extract features
 """
 
-from __future__ import absolute_import, division
-
 import logging
 import sys
 import warnings

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -14,8 +14,6 @@ set_property function. Only functions in this python module, which have a parame
 seen by tsfresh as a feature calculator. Others will not be calculated.
 """
 
-from __future__ import absolute_import, division
-
 import itertools
 import warnings
 from builtins import range

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -108,7 +108,7 @@ def _get_length_sequences_where(x):
 
 
 def _estimate_friedrich_coefficients(x, m, r):
-    """
+    r"""
     Coefficients of polynomial :math:`h(x)`, which has been fitted to
     the deterministic dynamics of Langevin model
     .. math::
@@ -457,7 +457,7 @@ def abs_energy(x):
 
     .. math::
 
-        E = \\sum_{i=1,\ldots, n} x_i^2
+        E = \\sum_{i=1,\\ldots, n} x_i^2
 
     :param x: the time series to calculate the feature of
     :type x: numpy.ndarray
@@ -513,7 +513,7 @@ def mean_abs_change(x):
 
     .. math::
 
-        \\frac{1}{n} \\sum_{i=1,\ldots, n-1} | x_{i+1} - x_{i}|
+        \\frac{1}{n} \\sum_{i=1,\\ldots, n-1} | x_{i+1} - x_{i}|
 
 
     :param x: the time series to calculate the feature of
@@ -531,7 +531,7 @@ def mean_change(x):
 
     .. math::
 
-        \\frac{1}{n} \\sum_{i=1,\ldots, n-1}  x_{i+1} - x_{i}
+        \\frac{1}{n} \\sum_{i=1,\\ldots, n-1}  x_{i+1} - x_{i}
 
     :param x: the time series to calculate the feature of
     :type x: numpy.ndarray
@@ -548,7 +548,7 @@ def mean_second_derivative_central(x):
 
     .. math::
 
-        \\frac{1}{n} \\sum_{i=1,\ldots, n-1}  \\frac{1}{2} (x_{i+2} - 2 \\cdot x_{i+1} + x_i)
+        \\frac{1}{n} \\sum_{i=1,\\ldots, n-1}  \\frac{1}{2} (x_{i+2} - 2 \\cdot x_{i+1} + x_i)
 
     :param x: the time series to calculate the feature of
     :type x: numpy.ndarray
@@ -669,7 +669,7 @@ def absolute_sum_of_changes(x):
 
     .. math::
 
-        \\sum_{i=1, \ldots, n-1} \\mid x_{i+1}- x_i \\mid
+        \\sum_{i=1, \\ldots, n-1} \\mid x_{i+1}- x_i \\mid
 
     :param x: the time series to calculate the feature of
     :type x: numpy.ndarray
@@ -935,7 +935,7 @@ def fft_coefficient(x, param):
     """
 
     assert min([config["coeff"] for config in param]) >= 0, "Coefficients must be positive or zero."
-    assert set([config["attr"] for config in param]) <= set(["imag", "real", "abs", "angle"]), \
+    assert {config["attr"] for config in param} <= {"imag", "real", "abs", "angle"}, \
         'Attribute must be "real", "imag", "angle" or "abs"'
 
     fft = np.fft.rfft(x)
@@ -970,12 +970,12 @@ def fft_aggregated(x, param):
     :return type: pandas.Series
     """
 
-    assert set([config["aggtype"] for config in param]) <= set(["centroid", "variance", "skew", "kurtosis"]), \
+    assert {config["aggtype"] for config in param} <= {"centroid", "variance", "skew", "kurtosis"}, \
         'Attribute must be "centroid", "variance", "skew", "kurtosis"'
 
 
     def get_moment(y, moment):
-        """
+        r"""
         Returns the (non centered) moment of the distribution y:
         E[y**moment] = \sum_i[index(y_i)^moment * y_i] / \sum_i[y_i]
         
@@ -1361,13 +1361,13 @@ def time_reversal_asymmetry_statistic(x, lag):
 
     .. math::
 
-        \\frac{1}{n-2lag} \sum_{i=0}^{n-2lag} x_{i + 2 \cdot lag}^2 \cdot x_{i + lag} - x_{i + lag} \cdot  x_{i}^2
+        \\frac{1}{n-2lag} \\sum_{i=0}^{n-2lag} x_{i + 2 \\cdot lag}^2 \\cdot x_{i + lag} - x_{i + lag} \\cdot  x_{i}^2
 
     which is
 
     .. math::
 
-        \\mathbb{E}[L^2(X)^2 \cdot L(X) - L(X) \cdot X^2]
+        \\mathbb{E}[L^2(X)^2 \\cdot L(X) - L(X) \\cdot X^2]
 
     where :math:`\\mathbb{E}` is the mean and :math:`L` is the lag operator. It was proposed in [1] as a
     promising feature to extract from time series.
@@ -1402,13 +1402,13 @@ def c3(x, lag):
 
     .. math::
 
-        \\frac{1}{n-2lag} \sum_{i=0}^{n-2lag} x_{i + 2 \cdot lag}^2 \cdot x_{i + lag} \cdot x_{i}
+        \\frac{1}{n-2lag} \\sum_{i=0}^{n-2lag} x_{i + 2 \\cdot lag}^2 \\cdot x_{i + lag} \\cdot x_{i}
 
     which is
 
     .. math::
 
-        \\mathbb{E}[L^2(X)^2 \cdot L(X) \cdot X]
+        \\mathbb{E}[L^2(X)^2 \\cdot L(X) \\cdot X]
 
     where :math:`\\mathbb{E}` is the mean and :math:`L` is the lag operator. It was proposed in [1] as a measure of
     non linearity in the time series.
@@ -1524,9 +1524,9 @@ def autocorrelation(x, lag):
 
     .. math::
 
-        \\frac{1}{(n-l)\sigma^{2}} \\sum_{t=1}^{n-l}(X_{t}-\\mu )(X_{t+l}-\\mu)
+        \\frac{1}{(n-l)\\sigma^{2}} \\sum_{t=1}^{n-l}(X_{t}-\\mu )(X_{t+l}-\\mu)
 
-    where :math:`n` is the length of the time series :math:`X_i`, :math:`\sigma^2` its variance and :math:`\mu` its
+    where :math:`n` is the length of the time series :math:`X_i`, :math:`\\sigma^2` its variance and :math:`\\mu` its
     mean. `l` denotes the lag.
 
     .. rubric:: References
@@ -1715,7 +1715,7 @@ def approximate_entropy(x, m, r):
 
 @set_property("fctype", "combiner")
 def friedrich_coefficients(x, param):
-    """
+    r"""
     Coefficients of polynomial :math:`h(x)`, which has been fitted to
     the deterministic dynamics of Langevin model
 
@@ -1766,7 +1766,7 @@ def friedrich_coefficients(x, param):
 
 @set_property("fctype", "simple")
 def max_langevin_fixed_point(x, r, m):
-    """
+    r"""
     Largest fixed point of dynamics  :math:argmax_x {h(x)=0}` estimated from polynomial :math:`h(x)`,
     which has been fitted to the deterministic dynamics of Langevin model
 

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -152,7 +152,7 @@ class ComprehensiveFCParameters(dict):
                              {"attr": "slope"}, {"attr": "stderr"}]
         })
 
-        super(ComprehensiveFCParameters, self).__init__(name_to_param)
+        super().__init__(name_to_param)
 
 
 class MinimalFCParameters(ComprehensiveFCParameters):

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -6,8 +6,6 @@ This file contains methods/objects for controlling which features will be extrac
 For the naming of the features, see :ref:`feature-naming-label`.
 """
 
-from __future__ import absolute_import, division
-
 from inspect import getargspec
 
 import pandas as pd

--- a/tsfresh/feature_selection/relevance.py
+++ b/tsfresh/feature_selection/relevance.py
@@ -10,8 +10,6 @@ Afterwards the Benjamini Hochberg procedure which is a multiple testing procedur
 which to cut off (solely based on the p-values).
 """
 
-from __future__ import absolute_import, division, print_function
-
 import logging
 from multiprocessing import Pool
 

--- a/tsfresh/feature_selection/selection.py
+++ b/tsfresh/feature_selection/selection.py
@@ -6,8 +6,6 @@ This module contains the filtering process for the extracted features. The filte
 other features that are not based on time series.
 """
 
-from __future__ import absolute_import
-
 import logging
 import pandas as pd
 import numpy as np

--- a/tsfresh/feature_selection/significance_tests.py
+++ b/tsfresh/feature_selection/significance_tests.py
@@ -28,8 +28,6 @@ References
 
 """
 
-
-from __future__ import absolute_import, division
 from builtins import str
 import numpy as np
 import pandas as pd

--- a/tsfresh/utilities/profiling.py
+++ b/tsfresh/utilities/profiling.py
@@ -9,7 +9,6 @@ from future import standard_library
 standard_library.install_aliases()
 import cProfile, pstats, io
 import logging
-import six
 
 
 _logger = logging.getLogger(__name__)
@@ -58,7 +57,7 @@ def end_profiling(profiler, filename, sorting=None):
     >>> end_profiling(profiler, "out.txt", "cumulative")
     """
     profiler.disable()
-    s = six.StringIO()
+    s = io.StringIO()
     ps = pstats.Stats(profiler, stream=s).sort_stats(sorting)
     ps.print_stats()
 

--- a/tsfresh/utilities/profiling.py
+++ b/tsfresh/utilities/profiling.py
@@ -5,8 +5,6 @@
 Contains methods to start and stop the profiler that checks the runtime of the different feature calculators
 """
 
-from future import standard_library
-standard_library.install_aliases()
 import cProfile, pstats, io
 import logging
 

--- a/tsfresh/utilities/string_manipulation.py
+++ b/tsfresh/utilities/string_manipulation.py
@@ -63,7 +63,7 @@ def convert_to_output_format(param):
     """
 
     def add_parenthesis_if_string_value(x):
-        if isinstance(x, string_types):
+        if isinstance(x, str):
             return '"' + str(x) + '"'
         else:
             return str(x)

--- a/tsfresh/utilities/string_manipulation.py
+++ b/tsfresh/utilities/string_manipulation.py
@@ -4,7 +4,6 @@
 
 import ast
 import numpy as np
-from six import string_types
 
 
 def get_config_from_string(parts):


### PR DESCRIPTION
Fixes #497.

Adds `python_requires` to help pip.

Also upgrade syntax with https://github.com/asottile/pyupgrade.
