### PR TITLE
Fix error about using pivot() in extraction.py

### DIFF
--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -319,7 +319,7 @@ def _do_extraction(df, column_id, column_value, column_kind,
         result["value"] = result["value"].astype(float)
 
     if len(result) != 0:
-        result = result.pivot("id", "variable", "value")
+        result = pd.pivot_table(result, index="id", columns="variable", values="value")
         result.index = result.index.astype(df[column_id].dtype)
 
     return result


### PR DESCRIPTION
If there is duplicate "id", pivot() function of pandas doesn't work. We should use pivot_table() function(https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.pivot_table.html)

Follow is the error message I got.
  File "/home/yeonsu/miniconda3/envs/ubisense/lib/python3.6/site-packages/tsfresh/feature_extraction/extraction.py", line 159, in extract_features
    distributor=distributor)
  File "/home/yeonsu/miniconda3/envs/ubisense/lib/python3.6/site-packages/tsfresh/feature_extraction/extraction.py", line 305, in _do_extraction
    result = result.pivot("id", "variable", "value")
  File "/home/yeonsu/miniconda3/envs/ubisense/lib/python3.6/site-packages/pandas/core/frame.py", line 5194, in pivot
    return pivot(self, index=index, columns=columns, values=values)
  File "/home/yeonsu/miniconda3/envs/ubisense/lib/python3.6/site-packages/pandas/core/reshape/reshape.py", line 415, in pivot
    return indexed.unstack(columns)
  File "/home/yeonsu/miniconda3/envs/ubisense/lib/python3.6/site-packages/pandas/core/series.py", line 2899, in unstack
    return unstack(self, level, fill_value)
  File "/home/yeonsu/miniconda3/envs/ubisense/lib/python3.6/site-packages/pandas/core/reshape/reshape.py", line 501, in unstack
    constructor=obj._constructor_expanddim)
  File "/home/yeonsu/miniconda3/envs/ubisense/lib/python3.6/site-packages/pandas/core/reshape/reshape.py", line 137, in __init__
    self._make_selectors()
  File "/home/yeonsu/miniconda3/envs/ubisense/lib/python3.6/site-packages/pandas/core/reshape/reshape.py", line 175, in _make_selectors
    raise ValueError('Index contains duplicate entries, '
ValueError: Index contains duplicate entries, cannot reshape