### PR TITLE
switch to scalar sum when features are not all independent

### DIFF
--- a/tsfresh/feature_selection/benjamini_hochberg_test.py
+++ b/tsfresh/feature_selection/benjamini_hochberg_test.py
@@ -52,7 +52,7 @@ def benjamini_hochberg_test(df_pvalues, hypotheses_independent, fdr_level):
         C = np.ones(m)
     else:
         # c(k) = \sum_{i=1}^m 1/i
-        C = np.cumsum(1.0 / K)
+        C = np.sum(1.0 / K)
 
     # Calculate the vector T to compare to the p_value
     T = (fdr_level * K) / (m * C)


### PR DESCRIPTION
np.sum sums all elements and presents a scalar C. Scalar C is then applied across the full range of K to form T. Tested it to make sure it didn't affect the use of T to compare p-values and determine relevance.