### PR TITLE
Update pandas version to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ install:
 jobs:
   include:
     - stage: Run unit tests and deploy
-      env: NUMPY="latest", PANDAS="0.23.4", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
+      env: NUMPY="latest", PANDAS="latest", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
       before_script:
         - pip install --upgrade numpy
-        - pip install pandas===0.23.4
+        - pip install --upgrade pandas
         - pip install scikit-learn==0.20.3 # last scikit-learn version to support python 2.7
         - pip install --upgrade dask
         - pip install --upgrade distributed
@@ -31,10 +31,10 @@ jobs:
         - coveralls
 
     - stage: Run unit tests and deploy
-      env: NUMPY="latest", PANDAS="0.23.4", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
+      env: NUMPY="latest", PANDAS="latest", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
       before_script:
         - pip install --upgrade numpy
-        - pip install pandas===0.23.4
+        - pip install --upgrade pandas
         - pip install --upgrade scikit-learn
         - pip install --upgrade dask
         - pip install --upgrade distributed
@@ -63,10 +63,10 @@ jobs:
       python: 2.7.11
 
     - stage: Run unit tests and deploy
-      env: NUMPY="1.10.4", PANDAS="0.20.3", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
+      env: NUMPY="1.10.4", PANDAS="latest", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
       before_script:
         - pip install numpy==1.10.4
-        - pip install pandas==0.20.3
+        - pip install --upgrade pandas
         - pip install scikit-learn==0.18.0
         - pip install dask==0.15.2
         - pip install distributed==1.18.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.9.1
 numpy>=1.10.4
-pandas>=0.20.3,<=0.23.4 # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
+pandas>=0.25.0
 scipy>=1.2.0
 statsmodels>=0.8.0
 patsy>=0.4.1


### PR DESCRIPTION
Tried to reproduce [this](https://github.com/blue-yonder/tsfresh/issues/485) error with `pandas==0.24.0` : Got the `TypeError`. 
On `pandas==0.25.0`, no errors. 

After running tests, I understand the story is a bit more complicated with python 3.5.2 and 2.7