### PR TITLE
Fix indexing of melted normalized input

### DIFF
--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -103,6 +103,36 @@ class NormalizeTestCase(TestCase):
         self.assertEqual(list(result_df[result_df[column_kind] == "b"]["_values"]), [5])
         self.assertEqual(list(result_df[result_df[column_kind] == "b"]["id"]), [0])
 
+    def test_with_df_4(self):
+        test_df0 = pd.DataFrame({"a": [1, 2], "b": [0, 1]})
+        test_df0["sort"] = test_df0.index
+        test_df0["id"] = 0
+
+        test_df1 = pd.DataFrame({"a": [1], "b": [1]})
+        test_df1["sort"] = test_df1.index
+        test_df1["id"] = 1
+
+        test_dfs = [test_df0, test_df1]
+        test_df = pd.concat(test_dfs, ignore_index=True)
+        melt_df, _, _, _ = \
+            dataframe_functions._normalize_input_to_internal_representation(test_df,
+                                                                            column_id="id",
+                                                                            column_sort="sort",
+                                                                            column_kind=None,
+                                                                            column_value=None)
+
+        # Verify that the order of values is correct after normalization
+        for idDf in [0, 1]:
+            self.assertEqual(
+                test_dfs[idDf]["a"].values.tolist(),
+                melt_df[(melt_df["id"] == idDf) & (melt_df["_variables"] == "a")]["_values"].values.tolist()
+            )
+
+            self.assertEqual(
+                test_dfs[idDf]["b"].values.tolist(),
+                melt_df[(melt_df["id"] == idDf) & (melt_df["_variables"] == "b")]["_values"].values.tolist()
+            )
+
     def test_with_wrong_input(self):
         test_df = pd.DataFrame([{"id": 0, "kind": "a", "value": 3, "sort": np.NaN}])
         self.assertRaises(ValueError, dataframe_functions._normalize_input_to_internal_representation, test_df,

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -315,7 +315,7 @@ def _normalize_input_to_internal_representation(timeseries_container, column_id,
             timeseries_container = pd.melt(timeseries_container.drop(column_sort, axis=1),
                                            id_vars=[column_id],
                                            value_name=column_value, var_name=column_kind)
-            timeseries_container[column_sort] = np.repeat(sort, (len(timeseries_container) // len(sort)))
+            timeseries_container[column_sort] = np.tile(sort, (len(timeseries_container) // len(sort)))
         else:
             column_kind = "_variables"
             column_value = "_values"
@@ -323,7 +323,7 @@ def _normalize_input_to_internal_representation(timeseries_container, column_id,
             sort = range(len(timeseries_container))
             timeseries_container = pd.melt(timeseries_container, id_vars=[column_id],
                                            value_name=column_value, var_name=column_kind)
-            timeseries_container[column_sort] = np.repeat(sort, (len(timeseries_container) // len(sort)))
+            timeseries_container[column_sort] = np.tile(sort, (len(timeseries_container) // len(sort)))
 
     # Check kind column
     if column_kind not in timeseries_container.columns:


### PR DESCRIPTION
When using tsfresh with batched df input without column_value or column_kind specified, tsfresh will automatically convert it to the required melted format in _normalize_input_to_internal_representation.

However, the pd.melt() function works differently than the code assumes. If the column_sort contains many various types of indices that do not overlap, this results in wrong input data, resulting in incorrect input data for feature generation!

Reasoning: pd.melt() does not interleave per-ID series, it stacks them. Therefore, when assigning back the column_sort, the column_sort needs to be tiled, not repeated.