### PR TITLE
Improve performance with Numpy's sum function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,19 @@ Changelog
 tsfresh uses `Semantic Versioning <http://semver.org/>`_
 
 
-Unreleased
-==========
+Version 0.12.0
+==============
+
+- fixed bugs
+    - wrong calculation of friedrich coefficients
+    - feature selection selected too many features
+    - an ignored max_timeshift parameter in roll_time_series
+- add deprecation warning for python 2
+- added support for index based features
+- new feature calculator
+    - linear_trend_timewise
+- enable the RelevantFeatureAugmenter to be used in cross validated pipelines
 - increased scipy dependency to 1.2.0
-- fixed bug in friedrich coefficient where the parameter were ignored and wrong features were returned
 
 
 Version 0.11.2
@@ -28,7 +37,7 @@ Version 0.11.1
 ==============
 - general performance improvements
 - removed hard pinning of dependencies
-- fixed
+- fixed bugs
     - the stock price forecasting notebook
     - the multi classification notebook
 

--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -1117,6 +1117,12 @@ class FeatureCalculationTestCase(TestCase):
         self.assertAlmostEqual(res["attr_\"intercept\""], 0, places=3)
         self.assertAlmostEqual(res["attr_\"slope\""], 1.0, places=3)
 
+    def test_change_quantiles(self):
+        """Test change_quantiles function when changing from `sum` to `np.sum`."""
+        np.random.seed(0)
+        res = change_quantiles(np.random.rand(10000) * 1000, 0.1, 0.2, False, 'mean')
+        self.assertAlmostEqual(res, -0.9443846621365727)
+
         
 class FriedrichTestCase(TestCase):
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -1345,7 +1345,7 @@ def change_quantiles(x, ql, qh, isabs, f_agg):
         return 0
     # We only count changes that start and end inside the corridor
     ind = (bin_cat_0 & _roll(bin_cat_0, 1))[1:]
-    if sum(ind) == 0:
+    if np.sum(ind) == 0:
         return 0
     else:
         ind_inside_corridor = np.where(ind == 1)

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -1119,7 +1119,7 @@ def index_mass_quantile(x, param):
 
     x = np.asarray(x)
     abs_x = np.abs(x)
-    s = sum(abs_x)
+    s = np.sum(abs_x)
 
     if s == 0:
         # all values in x are zero or it has length 0


### PR DESCRIPTION
The `change_quantiles` function need to sum the bool index array. Currently it's using the builtin `sum` function. However, NumPys `np.sum` will be faster on arrays.

I ran some test on it.
```python
import timeit
stmt = """change_quantiles(np.random.rand(300000) * 1000, 0.1, 0.2, False, 'mean')"""
print(timeit.timeit(stmt=stmt, setup='import numpy as np;from tsfresh.feature_extraction.feature_calculators import change_quantiles', number=1))
```
With the builtin `sum` function it takes 0.5s, while NumPys `np.sum` takes only 0.02s.
