### PR TITLE
Optimize mean_change (fixes issue #542) and correct documentation

### DIFF
--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -318,6 +318,9 @@ class FeatureCalculationTestCase(TestCase):
     def test_mean_change(self):
         self.assertEqualOnAllArrayTypes(mean_change, [-2, 2, 5], 3.5)
         self.assertEqualOnAllArrayTypes(mean_change, [1, 2, -1], -1)
+        self.assertEqualOnAllArrayTypes(mean_change, [10, 20], 10)
+        self.assertIsNanOnAllArrayTypes(mean_change, [1])
+        self.assertIsNanOnAllArrayTypes(mean_change, [])
 
     def test_mean_second_derivate_central(self):
         self.assertEqualOnAllArrayTypes(mean_second_derivative_central, list(range(10)), 0)

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -531,14 +531,15 @@ def mean_change(x):
 
     .. math::
 
-        \\frac{1}{n} \\sum_{i=1,\ldots, n-1}  x_{i+1} - x_{i}
+        \\frac{1}{n-1} \\sum_{i=1,\ldots, n-1}  x_{i+1} - x_{i} = \\frac{1}{n-1} (x_{n} - x_{1})
 
     :param x: the time series to calculate the feature of
     :type x: numpy.ndarray
     :return: the value of this feature
     :return type: float
     """
-    return np.mean(np.diff(x))
+    x = np.asarray(x)
+    return (x[-1] - x[0]) / (len(x) - 1) if len(x) > 1 else np.NaN
 
 
 @set_property("fctype", "simple")


### PR DESCRIPTION
This uses a simpler formula for calculating `mean_change` that was already proposed in #542. The proof for this simplification follows. Moreover, I fixed the documentation, because we actually divide by `n - 1` because a series with `n` elements only has `n - 1` differences. I also added a few test cases to check some corner cases.

![image](https://user-images.githubusercontent.com/10400532/66672514-b89eb300-ec5e-11e9-8c00-1626f756b4d1.png)