### PR TITLE
Preserve index when column_value and column_kind not provided

### DIFF
--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -321,8 +321,13 @@ def _normalize_input_to_internal_representation(timeseries_container, column_id,
             column_value = "_values"
             column_sort = "_sort"
             sort = range(len(timeseries_container))
-            timeseries_container = pd.melt(timeseries_container, id_vars=[column_id],
+
+            timeseries_container.index.name = 'index'
+            timeseries_container = pd.melt(timeseries_container.reset_index(),
+                                           id_vars=['index', column_id],
                                            value_name=column_value, var_name=column_kind)
+            timeseries_container = timeseries_container.set_index('index')
+
             timeseries_container[column_sort] = np.tile(sort, (len(timeseries_container) // len(sort)))
 
     # Check kind column

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -309,26 +309,22 @@ def _normalize_input_to_internal_representation(timeseries_container, column_id,
 
     if column_kind is None and column_value is None:
         if column_sort is not None:
-            column_kind = "_variables"
-            column_value = "_values"
             sort = timeseries_container[column_sort].values
-            timeseries_container = pd.melt(timeseries_container.drop(column_sort, axis=1),
-                                           id_vars=[column_id],
-                                           value_name=column_value, var_name=column_kind)
-            timeseries_container[column_sort] = np.tile(sort, (len(timeseries_container) // len(sort)))
+            timeseries_container = timeseries_container.drop(column_sort, axis=1)
         else:
-            column_kind = "_variables"
-            column_value = "_values"
-            column_sort = "_sort"
             sort = range(len(timeseries_container))
+            column_sort = "_sort"
 
-            timeseries_container.index.name = 'index'
-            timeseries_container = pd.melt(timeseries_container.reset_index(),
-                                           id_vars=['index', column_id],
-                                           value_name=column_value, var_name=column_kind)
-            timeseries_container = timeseries_container.set_index('index')
+        column_kind = "_variables"
+        column_value = "_values"
 
-            timeseries_container[column_sort] = np.tile(sort, (len(timeseries_container) // len(sort)))
+        timeseries_container.index.name = 'index'
+        timeseries_container = pd.melt(timeseries_container.reset_index(),
+                                       id_vars=['index', column_id],
+                                       value_name=column_value, var_name=column_kind)
+        timeseries_container = timeseries_container.set_index('index')
+
+        timeseries_container[column_sort] = np.tile(sort, (len(timeseries_container) // len(sort)))
 
     # Check kind column
     if column_kind not in timeseries_container.columns:


### PR DESCRIPTION
Hello,

This PR solves #557.  The support for  index based features introduced in tsfresh 0.12.0 only works when `column_kind` and `column_value` are passed to `extract_features()`. 

Here is an example of the issue:

```python
import pandas as pd
from tsfresh.feature_extraction import extract_features
from tsfresh.feature_extraction.settings import TimeBasedFCParameters  

df = pd.DataFrame({"id": ["a", "a", "a", "a", "b", "b", "b", "b"], 
                   "value": [1, 2, 3, 1, 3, 1, 0, 8],
                   "kind": ["temperature", "temperature", "pressure", "pressure",
                            "temperature", "temperature", "pressure", "pressure"]})

# Without pd.DatetimeIndex -> empty (as expected)
extracted = extract_features(df, column_id="id", column_value='value', column_kind='kind',
                             default_fc_parameters=TimeBasedFCParameters())
extracted.info()
#> <class 'pandas.core.frame.DataFrame'>
#> Index: 0 entries
#> Empty DataFrame
```

```python
# With pd.DatetimeIndex -> works
time_index = pd.DatetimeIndex(
    ['2019-03-01 10:04:00', '2019-03-01 10:50:00', '2019-03-02 00:00:00', '2019-03-02 09:04:59',
     '2019-03-02 23:54:12', '2019-03-03 08:13:04', '2019-03-04 08:00:00', '2019-03-04 08:01:00']
)
df = df.set_index(time_index).sort_index()
extracted = extract_features(df, column_id="id", column_value='value', column_kind='kind',
                             default_fc_parameters=TimeBasedFCParameters())
extracted.info()
#> <class 'pandas.core.frame.DataFrame'>
#> Index: 2 entries, a to b
#> Data columns (total 10 columns):
#> pressure__linear_trend_timewise__attr_"intercept"       2 non-null float64
#> pressure__linear_trend_timewise__attr_"pvalue"          2 non-null float64
#> pressure__linear_trend_timewise__attr_"rvalue"          2 non-null float64
#> pressure__linear_trend_timewise__attr_"slope"           2 non-null float64
#> pressure__linear_trend_timewise__attr_"stderr"          2 non-null float64
#> temperature__linear_trend_timewise__attr_"intercept"    2 non-null float64
#> temperature__linear_trend_timewise__attr_"pvalue"       2 non-null float64
#> temperature__linear_trend_timewise__attr_"rvalue"       2 non-null float64
#> temperature__linear_trend_timewise__attr_"slope"        2 non-null float64
#> temperature__linear_trend_timewise__attr_"stderr"       2 non-null float64
#> dtypes: float64(10)
#> memory usage: 176.0+ bytes
```

```python
# With pd.DatetimeIndex but without specifying column_value and column_kind 
# -> empty without this PR
extracted = (df
             .groupby('kind')
             .apply(lambda g : extract_features(g, column_id="id",
                          default_fc_parameters=TimeBasedFCParameters()))
            )
extracted.info()
#> <class 'pandas.core.frame.DataFrame'>
#> MultiIndex: 0 entries
#> Empty DataFrame
```

<sup>Created on 2019-10-16 by the [reprexpy package](https://github.com/crew102/reprexpy)</sup>

The bug comes from the index not being preserved when melting the dataframe in `_normalize_input_to_internal_representation`, specifically when `column_kind` and `column_value` are None.