### PR TITLE
Fix off-by-one error in longest strike features (fixes #577)

### DIFF
--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -372,11 +372,15 @@ class FeatureCalculationTestCase(TestCase):
 
     def test_longest_strike_below_mean(self):
         self.assertEqualOnAllArrayTypes(longest_strike_below_mean, [1, 2, 1, 1, 1, 2, 2, 2], 3)
+        self.assertEqualOnAllArrayTypes(longest_strike_below_mean, [1, 2, 3, 4, 5, 6], 3)
+        self.assertEqualOnAllArrayTypes(longest_strike_below_mean, [1, 2, 3, 4, 5], 2)
         self.assertEqualOnAllArrayTypes(longest_strike_below_mean, [1, 2, 1], 1)
         self.assertEqualOnAllArrayTypes(longest_strike_below_mean, [], 0)
 
     def test_longest_strike_above_mean(self):
         self.assertEqualOnAllArrayTypes(longest_strike_above_mean, [1, 2, 1, 2, 1, 2, 2, 1], 2)
+        self.assertEqualOnAllArrayTypes(longest_strike_above_mean, [1, 2, 3, 4, 5, 6], 3)
+        self.assertEqualOnAllArrayTypes(longest_strike_above_mean, [1, 2, 3, 4, 5], 2)
         self.assertEqualOnAllArrayTypes(longest_strike_above_mean, [1, 2, 1], 1)
         self.assertEqualOnAllArrayTypes(longest_strike_above_mean, [], 0)
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -691,7 +691,7 @@ def longest_strike_below_mean(x):
     """
     if not isinstance(x, (np.ndarray, pd.Series)):
         x = np.asarray(x)
-    return np.max(_get_length_sequences_where(x <= np.mean(x))) if x.size > 0 else 0
+    return np.max(_get_length_sequences_where(x < np.mean(x))) if x.size > 0 else 0
 
 
 @set_property("fctype", "simple")
@@ -706,7 +706,7 @@ def longest_strike_above_mean(x):
     """
     if not isinstance(x, (np.ndarray, pd.Series)):
         x = np.asarray(x)
-    return np.max(_get_length_sequences_where(x >= np.mean(x))) if x.size > 0 else 0
+    return np.max(_get_length_sequences_where(x > np.mean(x))) if x.size > 0 else 0
 
 
 @set_property("fctype", "simple")


### PR DESCRIPTION
Use less and greater operators instead of less-or-equal and greater-or-equal operators in `longest_strike_below_mean` and `longest_strike_above_mean` to fix issue #577. I additionally added a few more test cases on this corner case.