### PR TITLE
add @set_property("input", "pd.Series") when needed

### DIFF
--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -631,6 +631,7 @@ def variance(x):
 
 
 @set_property("fctype", "simple")
+@set_property("input", "pd.Series")
 def skewness(x):
     """
     Returns the sample skewness of x (calculated with the adjusted Fisher-Pearson standardized
@@ -647,6 +648,7 @@ def skewness(x):
 
 
 @set_property("fctype", "simple")
+@set_property("input", "pd.Series")
 def kurtosis(x):
     """
     Returns the kurtosis of x (calculated with the adjusted Fisher-Pearson standardized
@@ -827,6 +829,7 @@ def percentage_of_reoccurring_datapoints_to_all_datapoints(x):
 
 
 @set_property("fctype", "simple")
+@set_property("input", "pd.Series")
 def percentage_of_reoccurring_values_to_all_values(x):
     """
     Returns the ratio of unique values, that are present in the time series
@@ -1562,6 +1565,7 @@ def autocorrelation(x, lag):
 
 
 @set_property("fctype", "simple")
+@set_property("input", "pd.Series")
 def quantile(x, q):
     """
     Calculates the q quantile of x. This is the value of x greater than q% of the ordered values from x.
@@ -1573,7 +1577,8 @@ def quantile(x, q):
     :return: the value of this feature
     :return type: float
     """
-    x = pd.Series(x)
+    if not isinstance(x, pd.Series):
+        x = pd.Series(x)
     return pd.Series.quantile(x, q)
 
 


### PR DESCRIPTION
This ensures that _do_extraction_on_chunk will pass a Series argument
and not a Numpy array, and avoids a Series->ndarray->Series conversion.