### PR TITLE
ensure that get_moment() uses float computations

### DIFF
--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -986,7 +986,7 @@ def fft_aggregated(x, param):
         :return: the moment requested
         :return type: float
         """
-        return y.dot(np.arange(len(y))**moment) / y.sum()
+        return y.dot(np.arange(len(y), dtype=float)**moment) / y.sum()
 
     def get_centroid(y):
         """


### PR DESCRIPTION
According to #529, np.arange(4096)**3 overflows on Windows 10 because
dtype is set to int32.  Specify dtype=float to avoid overflows.