### PR TITLE
Fix docstring of c3

### DIFF
--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -1405,13 +1405,13 @@ def c3(x, lag):
 
     .. math::
 
-        \\frac{1}{n-2lag} \\sum_{i=0}^{n-2lag} x_{i + 2 \\cdot lag}^2 \\cdot x_{i + lag} \\cdot x_{i}
+        \\frac{1}{n-2lag} \\sum_{i=1}^{n-2lag} x_{i + 2 \\cdot lag} \\cdot x_{i + lag} \\cdot x_{i}
 
     which is
 
     .. math::
 
-        \\mathbb{E}[L^2(X)^2 \\cdot L(X) \\cdot X]
+        \\mathbb{E}[L^2(X) \\cdot L(X) \\cdot X]
 
     where :math:`\\mathbb{E}` is the mean and :math:`L` is the lag operator. It was proposed in [1] as a measure of
     non linearity in the time series.


### PR DESCRIPTION
There were two issues:
 * sum index should start from 1 and not 0
 * x[i+2*lag] should not be squared

Fix #585.