### PR TITLE
Early return from change_quantiles if ql >= qh

### DIFF
--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -1334,7 +1334,7 @@ def change_quantiles(x, ql, qh, isabs, f_agg):
     :return type: float
     """
     if ql >= qh:
-        ValueError("ql={} should be lower than qh={}".format(ql, qh))
+        return 0
 
     div = np.diff(x)
     if isabs:

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -133,7 +133,7 @@ class ComprehensiveFCParameters(dict):
             "ar_coefficient": [{"coeff": coeff, "k": k} for coeff in range(5) for k in [10]],
             "change_quantiles": [{"ql": ql, "qh": qh, "isabs": b, "f_agg": f}
                                           for ql in [0., .2, .4, .6, .8] for qh in [.2, .4, .6, .8, 1.]
-                                          for b in [False, True] for f in ["mean", "var"]],
+                                          for b in [False, True] for f in ["mean", "var"] if ql < qh],
             "fft_coefficient": [{"coeff": k, "attr": a} for a, k in product(["real", "imag", "abs", "angle"], range(100))],
             "fft_aggregated": [{"aggtype": s} for s in ["centroid", "variance", "skew", "kurtosis"]],
             "value_count": [{"value": value} for value in [0, 1, -1]],


### PR DESCRIPTION
Since 'raise' keyword was missing from this block:

      if ql >= qh:
          ValueError("ql={} should be lower than qh={}".format(ql, qh))

this test did nothing and 0 was returned after some computations.

Modify ComprehensiveFCParameters["change_quantiles"] to only consider parameters with ql < qh.