### PR TITLE
Compute quantiles and Friedrich coefficients only once

### DIFF
--- a/tests/units/feature_extraction/test_settings.py
+++ b/tests/units/feature_extraction/test_settings.py
@@ -163,7 +163,7 @@ class TestEfficientFCParameters(TestCase):
         """
         rfs = IndexBasedFCParameters()
         all_feature_calculators = [name for name, func in feature_calculators.__dict__.items()
-                                   if getattr(func, "input", None) == "pd.Series"]
+                                   if getattr(func, "fctype", False) and getattr(func, "input", None) == "pd.Series"]
 
         for calculator in all_feature_calculators:
             self.assertIn(calculator, rfs,

--- a/tsfresh/utilities/string_manipulation.py
+++ b/tsfresh/utilities/string_manipulation.py
@@ -67,5 +67,5 @@ def convert_to_output_format(param):
         else:
             return str(x)
 
-    return "__".join(str(key) + "_" + add_parenthesis_if_string_value(param[key]) for key in sorted(param.keys()))
+    return "__".join(str(key) + "_" + add_parenthesis_if_string_value(param[key]) for key in sorted(param.keys()) if not key.startswith("_"))
 


### PR DESCRIPTION
`change_quantiles()` is called with several ql and qh arguments. Quantile computation is costly, it is faster to compute all quantiles only once.
For each data chunk, this commit computes all quantiles which are needed, and put them in a `_quantiles` argument, which is used as a cache variable.  If it is set, it is used to speed-up computations.  Otherwise, everything is computed as before. This cache variable is not passed to convert_to_output_format.

Likewise for Friedrich coefficients.

This is a draft pull request, these changes may be controversial but on the other hand provide some nice speed-up.
