### PR TITLE
Feature/528 allow newest pandas version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
       env: NUMPY="latest", PANDAS="latest", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
       before_script:
         - pip install --upgrade numpy
-        - pip install --upgrade pandas
+        - pip install pandas===0.23.4 # pandas installation fails with newer version
         - pip install scikit-learn==0.20.3 # last scikit-learn version to support python 2.7
         - pip install --upgrade dask
         - pip install --upgrade distributed

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
       after_success:
         - coveralls
 
-    - stage: Run tests on oldest set of dependencies (Python 3.5)
+    - stage: Run tests on oldest set of dependencies (Python 3.5.3)
       env: NUMPY="1.12.0", PANDAS="0.20.3", SCIKITLEARN="0.19.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
       before_script:
         - pip install numpy==1.12.0  # First version with official python 3.6 support.
@@ -74,7 +74,7 @@ jobs:
       script:
         - sed -i 's/\-n auto/\-n 2/g' setup.cfg
         - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then pytest tests/units -n2; else pytest tests; fi"
-      python: 3.5.2
+      python: 3.5.3
 
     - stage: Run tests on oldest set of dependencies (Python 3.6)
       env: NUMPY="1.12.0", PANDAS="0.20.3", SCIKITLEARN="0.19.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ install:
 jobs:
   include:
     - stage: Run unit tests and deploy
-      env: NUMPY="latest", PANDAS="0.23.4", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
+      env: NUMPY="latest", PANDAS="latest", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
       before_script:
         - pip install --upgrade numpy
-        - pip install pandas===0.23.4
+        - pip install --upgrade pandas
         - pip install scikit-learn==0.20.3 # last scikit-learn version to support python 2.7
         - pip install --upgrade dask
         - pip install --upgrade distributed
@@ -31,10 +31,10 @@ jobs:
         - coveralls
 
     - stage: Run unit tests and deploy
-      env: NUMPY="latest", PANDAS="0.23.4", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
+      env: NUMPY="latest", PANDAS="latest", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
       before_script:
         - pip install --upgrade numpy
-        - pip install pandas===0.23.4
+        - pip install --upgrade pandas
         - pip install --upgrade scikit-learn
         - pip install --upgrade dask
         - pip install --upgrade distributed
@@ -63,10 +63,10 @@ jobs:
       python: 2.7
 
     - stage: Run unit tests and deploy
-      env: NUMPY="1.10.4", PANDAS="0.20.3", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
+      env: NUMPY="1.10.4", PANDAS="latest", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
       before_script:
         - pip install numpy==1.10.4
-        - pip install pandas==0.20.3
+        - pip install --upgrade pandas
         - pip install scikit-learn==0.18.0
         - pip install dask==0.15.2
         - pip install distributed==1.18.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip freeze
 jobs:
   include:
-    - stage: Run unit tests and deploy
+    - stage: Run tests on newest set of dependencies (Python 2.7)
       env: NUMPY="latest", PANDAS="latest", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
       before_script:
         - pip install --upgrade numpy
@@ -30,7 +30,7 @@ jobs:
       after_success:
         - coveralls
 
-    - stage: Run unit tests and deploy
+    - stage: Run tests on newest set of dependencies (Python 3.5)
       env: NUMPY="latest", PANDAS="latest", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
       before_script:
         - pip install --upgrade numpy
@@ -45,7 +45,7 @@ jobs:
         - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then pytest tests/units -n2; else pytest tests; fi"
       python: 3.5
 
-    - stage: Run unit tests and deploy
+    - stage: Run tests on oldest set of dependencies (Python 2.7)
       env: NUMPY="1.10.4", PANDAS="0.20.3", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
       before_script:
         - pip install numpy==1.10.4
@@ -62,11 +62,11 @@ jobs:
         - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then pytest tests/units -n2; else pytest tests; fi"
       python: 2.7
 
-    - stage: Run unit tests and deploy
-      env: NUMPY="1.10.4", PANDAS="latest", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
+    - stage: Run tests on oldest set of dependencies (Python 3.5)
+      env: NUMPY="1.10.4", PANDAS="0.20.3", SCIKITLEARN="0.18.0", DASK="0.15.2", DISTRIBUTED="1.18.3", SCIPY="1.2.0"
       before_script:
         - pip install numpy==1.10.4
-        - pip install --upgrade pandas
+        - pip install pandas==0.20.3
         - pip install scikit-learn==0.18.0
         - pip install dask==0.15.2
         - pip install distributed==1.18.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip freeze
 jobs:
   include:
-    - stage: Run tests on newest set of dependencies (Python 3.5.2)
+    - stage: Run tests on newest set of dependencies (Python 3.5.3)
       env: NUMPY="latest", PANDAS="latest", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"
       before_script:
         - pip install --upgrade numpy
@@ -24,7 +24,7 @@ jobs:
       script:
         - sed -i 's/\-n auto/\-n 2/g' setup.cfg
         - "if [ $TRAVIS_PULL_REQUEST == false ] && ! [ $TRAVIS_BRANCH == 'master' ]; then pytest tests/units -n2; else pytest tests; fi"
-      python: 3.5.2
+      python: 3.5.3
 
     - stage: Run tests on newest set of dependencies (Python 3.6)
       env: NUMPY="latest", PANDAS="latest", SCIKITLEARN="latest", DASK="latest", DISTRIBUTED="latest", SCIPY="latest"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.9.1
 numpy>=1.10.4
-pandas>=0.25.0
+pandas>=0.20.3,!=0.24.* # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
 scipy>=1.2.0
 statsmodels>=0.8.0
 patsy>=0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.9.1
 numpy>=1.10.4
-pandas>=0.20.3,<=0.23.4 # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
+pandas>=0.25.0
 scipy>=1.2.0
 statsmodels>=0.8.0
 patsy>=0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests>=2.9.1
 numpy>=1.10.4
-pandas>=0.20.3,!=0.24.* # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
+pandas>=0.20.3,<0.23.4; python_version <= '2.7'
+pandas>=0.20.3,!=0.24.*; python_version > '3' # pandas dropna is buggy in 0.24.0, see https://github.com/blue-yonder/tsfresh/issues/485 and https://github.com/pandas-dev/pandas/issues/25087
 scipy>=1.2.0
 statsmodels>=0.8.0
 patsy>=0.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifier =
     Topic :: Software Development
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.5.3
 
 [entry_points]
 # Add here console scripts like:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifier =
     Topic :: Software Development
 
 [options]
-python_requires = >= 3.5.3
+python_requires = >= 3.5
 
 [entry_points]
 # Add here console scripts like:

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -554,7 +554,7 @@ class ImputeTestCase(TestCase):
 
         df = pd.DataFrame(np.transpose([[0, 1, 2, np.NaN], [1, np.PINF, 2, np.NaN], [np.NaN, -3, np.NINF, 3]]),
                           columns=["value_a", "value_b", "value_c"])
-        df = df.astype(np.float64, inplace=True)
+        df = df.astype(np.float64)
         dataframe_functions.impute(df)
 
         self.assertEqual(list(df.value_a), [0, 1, 2, 1])
@@ -563,7 +563,7 @@ class ImputeTestCase(TestCase):
 
         df = pd.DataFrame(np.transpose([[0, 1, 2, np.NaN], [1, np.PINF, 2, 3], [np.PINF, -3, np.NINF, 3]]),
                           columns=["value_a", "value_b", "value_c"])
-        df = df.astype(np.float32, inplace=True)
+        df = df.astype(np.float32)
         dataframe_functions.impute(df)
 
         self.assertEqual(list(df.value_a), [0, 1, 2, 1])

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -1600,8 +1600,9 @@ def number_crossing_m(x, m):
     if not isinstance(x, (np.ndarray, pd.Series)):
         x = np.asarray(x)
     # From https://stackoverflow.com/questions/3843017/efficiently-detect-sign-changes-in-python
+    # However, we are not going with the fastest version as it breaks with pandas
     positive = x > m
-    return np.where(np.bitwise_xor(positive[1:], positive[:-1]))[0].size
+    return np.where(np.diff(positive))[0].size
 
 
 @set_property("fctype", "simple")


### PR DESCRIPTION
This builds on top of #562 and fixes the two unit tests.

It also does not require the newest version of pandas, but only to not be 0.24.*

PS: we should really fix the .travis.yaml, I have the strong feeling we are not doing this very optimally... I especially do not like the specification of the versions. Will tackle this later.

@dbarbier Are you fine with this?