### PR TITLE
Fix filtering on warnings with multiprocessing on Windows

### DIFF
--- a/tests/units/feature_selection/test_relevance.py
+++ b/tests/units/feature_selection/test_relevance.py
@@ -93,11 +93,13 @@ class TestCalculateRelevanceTable:
         significance_test_feature_binary_mock.return_value = 0.95
         significance_test_feature_real_mock.return_value = 0.95
 
-        with mock.patch('logging.Logger.warning') as m:
-            _ = calculate_relevance_table(X, y_real, n_jobs=0, ml_task="regression")
-            m.assert_called_with("No feature was found relevant for regression for fdr level = 0.05 (which corresponds "
-                                 "to the maximal percentage of irrelevant features, consider using an higher fdr level "
-                                 "or add other features.")
+        with pytest.warns(RuntimeWarning) as record:
+            _ = calculate_relevance_table(X, y_real, n_jobs=0, ml_task="regression", show_warnings=True)
+            assert len(record) == 1
+            assert str(record[0].message) == (
+                "No feature was found relevant for regression for fdr level = 0.05 (which corresponds "
+                "to the maximal percentage of irrelevant features, consider using an higher fdr level "
+                "or add other features." )
 
 
 class TestCombineRelevanceTables:

--- a/tests/units/feature_selection/test_relevance.py
+++ b/tests/units/feature_selection/test_relevance.py
@@ -99,7 +99,7 @@ class TestCalculateRelevanceTable:
             assert str(record[0].message) == (
                 "No feature was found relevant for regression for fdr level = 0.05 (which corresponds "
                 "to the maximal percentage of irrelevant features, consider using an higher fdr level "
-                "or add other features." )
+                "or add other features.")
 
 
 class TestCombineRelevanceTables:

--- a/tsfresh/convenience/relevant_extraction.py
+++ b/tsfresh/convenience/relevant_extraction.py
@@ -170,6 +170,7 @@ def extract_relevant_features(timeseries_container, y, X=None,
                             test_for_real_target_real_feature=test_for_real_target_real_feature,
                             fdr_level=fdr_level, hypotheses_independent=hypotheses_independent,
                             n_jobs=n_jobs,
+                            show_warnings=show_warnings,
                             chunksize=chunksize,
                             ml_task=ml_task)
 

--- a/tsfresh/convenience/relevant_extraction.py
+++ b/tsfresh/convenience/relevant_extraction.py
@@ -87,7 +87,7 @@ def extract_relevant_features(timeseries_container, y, X=None,
     :param n_jobs: The number of processes to use for parallelization. If zero, no parallelization is used.
     :type n_jobs: int
 
-    :param: show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
+    :param show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
     :type show_warnings: bool
 
     :param disable_progressbar: Do not show a progressbar while doing the calculation.

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -106,7 +106,7 @@ def extract_features(timeseries_container, default_fc_parameters=None,
         smaller chunksize.
     :type chunksize: None or int
 
-    :param: show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
+    :param show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
     :type show_warnings: bool
 
     :param disable_progressbar: Do not show a progressbar while doing the calculation.
@@ -163,6 +163,7 @@ def extract_features(timeseries_container, default_fc_parameters=None,
                                 column_kind=column_kind,
                                 n_jobs=n_jobs, chunk_size=chunksize,
                                 disable_progressbar=disable_progressbar,
+                                show_warnings=show_warnings,
                                 default_fc_parameters=default_fc_parameters,
                                 kind_to_fc_parameters=kind_to_fc_parameters,
                                 distributor=distributor)
@@ -243,7 +244,7 @@ def generate_data_chunk_format(df, column_id, column_kind, column_value):
 
 def _do_extraction(df, column_id, column_value, column_kind,
                    default_fc_parameters, kind_to_fc_parameters,
-                   n_jobs, chunk_size, disable_progressbar, distributor):
+                   n_jobs, chunk_size, disable_progressbar, show_warnings, distributor):
     """
     Wrapper around the _do_extraction_on_chunk, which calls it on all chunks in the data frame.
     A chunk is a subset of the data, with a given kind and id - so a single time series.
@@ -285,6 +286,9 @@ def _do_extraction(df, column_id, column_value, column_kind,
     :param disable_progressbar: Do not show a progressbar while doing the calculation.
     :type disable_progressbar: bool
 
+    :param show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
+    :type show_warnings: bool
+
     :param distributor: Advanced parameter:  See the utilities/distribution.py for more information.
                          Leave to None, if you want TSFresh to choose the best distributor.
     :type distributor: DistributorBaseClass
@@ -302,7 +306,8 @@ def _do_extraction(df, column_id, column_value, column_kind,
         else:
             distributor = MultiprocessingDistributor(n_workers=n_jobs,
                                                      disable_progressbar=disable_progressbar,
-                                                     progressbar_title="Feature Extraction")
+                                                     progressbar_title="Feature Extraction",
+                                                     show_warnings=show_warnings)
 
     if not isinstance(distributor, DistributorBaseClass):
         raise ValueError("the passed distributor is not an DistributorBaseClass object")
@@ -317,7 +322,7 @@ def _do_extraction(df, column_id, column_value, column_kind,
 
     # Return a dataframe in the typical form (id as index and feature names as columns)
     result = pd.DataFrame(result)
-    if result.columns.contains("value"):
+    if "value" in result.columns:
         result["value"] = result["value"].astype(float)
 
     if len(result) != 0:

--- a/tsfresh/feature_selection/relevance.py
+++ b/tsfresh/feature_selection/relevance.py
@@ -24,7 +24,6 @@ from tsfresh.feature_selection.significance_tests import target_binary_feature_r
 from tsfresh.utilities.distribution import initialize_warnings_in_workers
 
 
-
 def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES,
                               show_warnings=defaults.SHOW_WARNINGS, chunksize=defaults.CHUNKSIZE,
                               test_for_binary_target_binary_feature=defaults.TEST_FOR_BINARY_TARGET_BINARY_FEATURE,
@@ -163,7 +162,8 @@ def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES,
         table_const['relevant'] = False
 
         if not table_const.empty:
-            warnings.warn("[test_feature_significance] Constant features: {}".format(", ".join(table_const.feature)), RuntimeWarning)
+            warnings.warn("[test_feature_significance] Constant features: {}"
+                          .format(", ".join(table_const.feature)), RuntimeWarning)
 
         if len(table_const) == len(relevance_table):
             if n_jobs != 0:
@@ -176,7 +176,7 @@ def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES,
             tables = []
             for label in y.unique():
                 _test_real_feature = partial(target_binary_feature_real_test, y=(y == label),
-                                            test=test_for_binary_target_real_feature)
+                                             test=test_for_binary_target_real_feature)
                 _test_binary_feature = partial(target_binary_feature_binary_test, y=(y == label))
                 tmp = _calculate_relevance_table_for_implicit_target(
                     table_real, table_binary, X, _test_real_feature, _test_binary_feature, hypotheses_independent,
@@ -188,8 +188,8 @@ def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES,
             _test_real_feature = partial(target_real_feature_real_test, y=y)
             _test_binary_feature = partial(target_real_feature_binary_test, y=y)
             relevance_table = _calculate_relevance_table_for_implicit_target(
-                table_real, table_binary, X, _test_real_feature, _test_binary_feature, hypotheses_independent, fdr_level,
-                map_function
+                table_real, table_binary, X, _test_real_feature, _test_binary_feature, hypotheses_independent,
+                fdr_level, map_function
             )
 
         if n_jobs != 0:
@@ -201,8 +201,9 @@ def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES,
 
         if sum(relevance_table['relevant']) == 0:
             warnings.warn(
-                "No feature was found relevant for {} for fdr level = {} (which corresponds to the maximal percentage of "
-                "irrelevant features, consider using an higher fdr level or add other features.".format(ml_task, fdr_level), RuntimeWarning)
+                "No feature was found relevant for {} for fdr level = {} (which corresponds to the maximal percentage "
+                "of irrelevant features, consider using an higher fdr level or add other features."
+                .format(ml_task, fdr_level), RuntimeWarning)
 
     return relevance_table
 

--- a/tsfresh/feature_selection/relevance.py
+++ b/tsfresh/feature_selection/relevance.py
@@ -10,11 +10,10 @@ Afterwards the Benjamini Hochberg procedure which is a multiple testing procedur
 which to cut off (solely based on the p-values).
 """
 
-import logging
 from multiprocessing import Pool
+import warnings
 
 import numpy as np
-import os
 import pandas as pd
 from functools import partial, reduce
 
@@ -22,11 +21,12 @@ from tsfresh import defaults
 from tsfresh.feature_selection.benjamini_hochberg_test import benjamini_hochberg_test
 from tsfresh.feature_selection.significance_tests import target_binary_feature_real_test, \
     target_real_feature_binary_test, target_real_feature_real_test, target_binary_feature_binary_test
+from tsfresh.utilities.distribution import initialize_warnings_in_workers
 
-_logger = logging.getLogger(__name__)
 
 
-def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES, chunksize=defaults.CHUNKSIZE,
+def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES,
+                              show_warnings=defaults.SHOW_WARNINGS, chunksize=defaults.CHUNKSIZE,
                               test_for_binary_target_binary_feature=defaults.TEST_FOR_BINARY_TARGET_BINARY_FEATURE,
                               test_for_binary_target_real_feature=defaults.TEST_FOR_BINARY_TARGET_REAL_FEATURE,
                               test_for_real_target_binary_feature=defaults.TEST_FOR_REAL_TARGET_BINARY_FEATURE,
@@ -110,6 +110,9 @@ def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES,
     :param n_jobs: Number of processes to use during the p-value calculation
     :type n_jobs: int
 
+    :param show_warnings: Show warnings during the p-value calculation (needed for debugging of calculators).
+    :type show_warnings: bool
+
     :param chunksize: The size of one chunk that is submitted to the worker
         process for the parallelisation.  Where one chunk is defined as a
         singular time series for one id and one kind. If you set the chunksize
@@ -134,59 +137,72 @@ def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES,
     elif ml_task == 'auto':
         ml_task = infer_ml_task(y)
 
-    if n_jobs == 0:
-        map_function = map
-    else:
-        pool = Pool(n_jobs)
-        map_function = partial(pool.map, chunksize=chunksize)
+    with warnings.catch_warnings():
+        if not show_warnings:
+            warnings.simplefilter("ignore")
+        else:
+            warnings.simplefilter("default")
 
-    relevance_table = pd.DataFrame(index=pd.Series(X.columns, name='feature'))
-    relevance_table['feature'] = relevance_table.index
-    relevance_table['type'] = pd.Series(
-        map_function(get_feature_type, [X[feature] for feature in relevance_table.index]),
-        index=relevance_table.index
-    )
-    table_real = relevance_table[relevance_table.type == 'real'].copy()
-    table_binary = relevance_table[relevance_table.type == 'binary'].copy()
+        if n_jobs == 0:
+            map_function = map
+        else:
+            pool = Pool(processes=n_jobs, initializer=initialize_warnings_in_workers, initargs=(show_warnings,))
+            map_function = partial(pool.map, chunksize=chunksize)
 
-    table_const = relevance_table[relevance_table.type == 'constant'].copy()
-    table_const['p_value'] = np.NaN
-    table_const['relevant'] = False
-
-    if len(table_const) == len(relevance_table):
-        return table_const
-
-    if ml_task == 'classification':
-        tables = []
-        for label in y.unique():
-            _test_real_feature = partial(target_binary_feature_real_test, y=(y == label),
-                                         test=test_for_binary_target_real_feature)
-            _test_binary_feature = partial(target_binary_feature_binary_test, y=(y == label))
-            tmp = _calculate_relevance_table_for_implicit_target(
-                table_real, table_binary, X, _test_real_feature, _test_binary_feature, hypotheses_independent,
-                fdr_level, map_function
-            )
-            tables.append(tmp)
-        relevance_table = combine_relevance_tables(tables)
-    elif ml_task == 'regression':
-        _test_real_feature = partial(target_real_feature_real_test, y=y)
-        _test_binary_feature = partial(target_real_feature_binary_test, y=y)
-        relevance_table = _calculate_relevance_table_for_implicit_target(
-            table_real, table_binary, X, _test_real_feature, _test_binary_feature, hypotheses_independent, fdr_level,
-            map_function
+        relevance_table = pd.DataFrame(index=pd.Series(X.columns, name='feature'))
+        relevance_table['feature'] = relevance_table.index
+        relevance_table['type'] = pd.Series(
+            map_function(get_feature_type, [X[feature] for feature in relevance_table.index]),
+            index=relevance_table.index
         )
+        table_real = relevance_table[relevance_table.type == 'real'].copy()
+        table_binary = relevance_table[relevance_table.type == 'binary'].copy()
 
-    relevance_table = pd.concat([relevance_table, table_const], axis=0)
+        table_const = relevance_table[relevance_table.type == 'constant'].copy()
+        table_const['p_value'] = np.NaN
+        table_const['relevant'] = False
 
-    if n_jobs != 0:
-        pool.close()
-        pool.terminate()
-        pool.join()
+        if not table_const.empty:
+            warnings.warn("[test_feature_significance] Constant features: {}".format(", ".join(table_const.feature)), RuntimeWarning)
 
-    if sum(relevance_table['relevant']) == 0:
-        _logger.warning(
-            "No feature was found relevant for {} for fdr level = {} (which corresponds to the maximal percentage of "
-            "irrelevant features, consider using an higher fdr level or add other features.".format(ml_task, fdr_level))
+        if len(table_const) == len(relevance_table):
+            if n_jobs != 0:
+                pool.close()
+                pool.terminate()
+                pool.join()
+            return table_const
+
+        if ml_task == 'classification':
+            tables = []
+            for label in y.unique():
+                _test_real_feature = partial(target_binary_feature_real_test, y=(y == label),
+                                            test=test_for_binary_target_real_feature)
+                _test_binary_feature = partial(target_binary_feature_binary_test, y=(y == label))
+                tmp = _calculate_relevance_table_for_implicit_target(
+                    table_real, table_binary, X, _test_real_feature, _test_binary_feature, hypotheses_independent,
+                    fdr_level, map_function
+                )
+                tables.append(tmp)
+            relevance_table = combine_relevance_tables(tables)
+        elif ml_task == 'regression':
+            _test_real_feature = partial(target_real_feature_real_test, y=y)
+            _test_binary_feature = partial(target_real_feature_binary_test, y=y)
+            relevance_table = _calculate_relevance_table_for_implicit_target(
+                table_real, table_binary, X, _test_real_feature, _test_binary_feature, hypotheses_independent, fdr_level,
+                map_function
+            )
+
+        if n_jobs != 0:
+            pool.close()
+            pool.terminate()
+            pool.join()
+
+        relevance_table = pd.concat([relevance_table, table_const], axis=0)
+
+        if sum(relevance_table['relevant']) == 0:
+            warnings.warn(
+                "No feature was found relevant for {} for fdr level = {} (which corresponds to the maximal percentage of "
+                "irrelevant features, consider using an higher fdr level or add other features.".format(ml_task, fdr_level), RuntimeWarning)
 
     return relevance_table
 
@@ -222,7 +238,6 @@ def infer_ml_task(y):
     else:
         ml_task = 'regression'
 
-    _logger.warning('Infered {} as machine learning task'.format(ml_task))
     return ml_task
 
 
@@ -255,7 +270,6 @@ def get_feature_type(feature_column):
     """
     n_unique_values = len(set(feature_column.values))
     if n_unique_values == 1:
-        _logger.warning("[test_feature_significance] Feature {} is constant".format(feature_column.name))
         return 'constant'
     elif n_unique_values == 2:
         return 'binary'

--- a/tsfresh/feature_selection/selection.py
+++ b/tsfresh/feature_selection/selection.py
@@ -6,7 +6,6 @@ This module contains the filtering process for the extracted features. The filte
 other features that are not based on time series.
 """
 
-import logging
 import pandas as pd
 import numpy as np
 from tsfresh import defaults
@@ -14,16 +13,13 @@ from tsfresh.utilities.dataframe_functions import check_for_nans_in_columns
 from tsfresh.feature_selection.relevance import calculate_relevance_table
 
 
-_logger = logging.getLogger(__name__)
-
-
 def select_features(X, y, test_for_binary_target_binary_feature=defaults.TEST_FOR_BINARY_TARGET_BINARY_FEATURE,
                     test_for_binary_target_real_feature=defaults.TEST_FOR_BINARY_TARGET_REAL_FEATURE,
                     test_for_real_target_binary_feature=defaults.TEST_FOR_REAL_TARGET_BINARY_FEATURE,
                     test_for_real_target_real_feature=defaults.TEST_FOR_REAL_TARGET_REAL_FEATURE,
                     fdr_level=defaults.FDR_LEVEL, hypotheses_independent=defaults.HYPOTHESES_INDEPENDENT,
-                    n_jobs=defaults.N_PROCESSES, chunksize=defaults.CHUNKSIZE,
-                    ml_task='auto'):
+                    n_jobs=defaults.N_PROCESSES, show_warnings=defaults.SHOW_WARNINGS,
+                    chunksize=defaults.CHUNKSIZE, ml_task='auto'):
     """
     Check the significance of all features (columns) of feature matrix X and return a possibly reduced feature matrix
     only containing relevant features.
@@ -105,6 +101,9 @@ def select_features(X, y, test_for_binary_target_binary_feature=defaults.TEST_FO
     :param n_jobs: Number of processes to use during the p-value calculation
     :type n_jobs: int
 
+    :param show_warnings: Show warnings during the p-value calculation (needed for debugging of calculators).
+    :type show_warnings: bool
+
     :param chunksize: The size of one chunk that is submitted to the worker
         process for the parallelisation.  Where one chunk is defined as a
         singular time series for one id and one kind. If you set the chunksize
@@ -142,7 +141,7 @@ def select_features(X, y, test_for_binary_target_binary_feature=defaults.TEST_FO
         y = pd.Series(y, index=X.index)
 
     relevance_table = calculate_relevance_table(
-        X, y, ml_task=ml_task, n_jobs=n_jobs, chunksize=chunksize,
+        X, y, ml_task=ml_task, n_jobs=n_jobs, show_warnings=show_warnings, chunksize=chunksize,
         test_for_binary_target_real_feature=test_for_binary_target_real_feature,
         fdr_level=fdr_level, hypotheses_independent=hypotheses_independent,
     )

--- a/tsfresh/feature_selection/significance_tests.py
+++ b/tsfresh/feature_selection/significance_tests.py
@@ -36,10 +36,7 @@ from builtins import str
 import numpy as np
 import pandas as pd
 from scipy import stats
-import logging
-
-
-_logger = logging.getLogger(__name__)
+import warnings
 
 
 def target_binary_feature_binary_test(x, y):
@@ -222,9 +219,9 @@ def __check_for_binary_target(y):
     :raises: ``ValueError`` if the values are not binary.
     """
     if not set(y) == {0, 1}:
-        _logger.warning("[target_binary_feature_binary_test] The binary target should have "
-                        "values 1 and 0 (or True and False). "
-                        "Instead found" + str(set(y)))
+        warnings.warn("[target_binary_feature_binary_test] The binary target should have "
+                      "values 1 and 0 (or True and False). "
+                      "Instead found" + str(set(y)), RuntimeWarning)
         if len(set(y)) > 2:
             raise ValueError("[target_binary_feature_binary_test] Target is not binary!")
 
@@ -243,9 +240,9 @@ def __check_for_binary_feature(x):
     :raises: ``ValueError`` if the values are not binary.
     """
     if not set(x) == {0, 1}:
-        _logger.warning("[target_binary_feature_binary_test] A binary feature should have only "
-                        "values 1 and 0 (incl. True and False). "
-                        "Instead found " + str(set(x)) + " in feature ''" + str(x.name) + "''.")
+        warnings.warn("[target_binary_feature_binary_test] A binary feature should have only "
+                      "values 1 and 0 (incl. True and False). "
+                      "Instead found " + str(set(x)) + " in feature ''" + str(x.name) + "''.", RuntimeWarning)
         if len(set(x)) > 2:
             raise ValueError("[target_binary_feature_binary_test] Feature is not binary!")
 

--- a/tsfresh/transformers/feature_augmenter.py
+++ b/tsfresh/transformers/feature_augmenter.py
@@ -103,7 +103,7 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
             smaller chunksize.
         :type chunksize: None or int
 
-        :param: show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
+        :param show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
         :type show_warnings: bool
 
         :param disable_progressbar: Do not show a progressbar while doing the calculation.

--- a/tsfresh/transformers/relevant_feature_augmenter.py
+++ b/tsfresh/transformers/relevant_feature_augmenter.py
@@ -145,7 +145,7 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         :param n_jobs: The number of processes to use for parallelization. If zero, no parallelization is used.
         :type n_jobs: int
 
-        :param: show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
+        :param show_warnings: Show warnings during the feature extraction (needed for debugging of calculators).
         :type show_warnings: bool
 
         :param disable_progressbar: Do not show a progressbar while doing the calculation.

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -10,9 +10,6 @@ import warnings
 
 import numpy as np
 import pandas as pd
-import logging
-
-_logger = logging.getLogger(__name__)
 
 
 def check_for_nans_in_columns(df, columns=None):
@@ -169,8 +166,8 @@ def get_range_values_per_column(df):
 
     if np.any(is_col_non_finite):
         # We have columns that does not contain any finite value at all, so we will store 0 instead.
-        _logger.warning("The columns {} did not have any finite values. Filling with zeros.".format(
-            df.iloc[:, np.where(is_col_non_finite)[0]].columns.values))
+        warnings.warn("The columns {} did not have any finite values. Filling with zeros.".format(
+            df.iloc[:, np.where(is_col_non_finite)[0]].columns.values), RuntimeWarning)
 
         masked.data[:, is_col_non_finite] = 0  # Set the values of the columns to 0
         masked.mask[:, is_col_non_finite] = False  # Remove the mask for this column

--- a/tsfresh/utilities/distribution.py
+++ b/tsfresh/utilities/distribution.py
@@ -10,6 +10,7 @@ Design of this module by Nils Braun
 
 import math
 import itertools
+import warnings
 from collections import Iterable
 from functools import partial
 from multiprocessing import Pool
@@ -37,6 +38,23 @@ def _function_with_partly_reduce(chunk_list, map_function, kwargs):
     results = (map_function(chunk, **kwargs) for chunk in chunk_list)
     results = list(itertools.chain.from_iterable(results))
     return results
+
+
+def initialize_warnings_in_workers(show_warnings):
+    """
+    Small helper function to initialize warnings module in multiprocessing workers.
+
+    On Windows, Python spawns fresh processes which do not inherit from warnings
+    state, so warnings must be enabled/disabled before running computations.
+
+    :param show_warnings: whether to show warnings or not.
+    :type show_warnings: bool
+    """
+    warnings.catch_warnings()
+    if not show_warnings:
+        warnings.simplefilter("ignore")
+    else:
+        warnings.simplefilter("default")
 
 
 class DistributorBaseClass:
@@ -337,7 +355,7 @@ class MultiprocessingDistributor(DistributorBaseClass):
     Distributor using a multiprocessing Pool to calculate the jobs in parallel on the local machine.
     """
 
-    def __init__(self, n_workers, disable_progressbar=False, progressbar_title="Feature Extraction"):
+    def __init__(self, n_workers, disable_progressbar=False, progressbar_title="Feature Extraction", show_warnings=True):
         """
         Creates a new MultiprocessingDistributor instance
 
@@ -347,8 +365,10 @@ class MultiprocessingDistributor(DistributorBaseClass):
         :type disable_progressbar: bool
         :param progressbar_title: the title of the progressbar
         :type progressbar_title: basestring
+        :param show_warnings: whether to show warnings or not.
+        :type show_warnings: bool
         """
-        self.pool = Pool(processes=n_workers)
+        self.pool = Pool(processes=n_workers, initializer=initialize_warnings_in_workers, initargs=(show_warnings,))
         self.n_workers = n_workers
         self.disable_progressbar = disable_progressbar
         self.progressbar_title = progressbar_title

--- a/tsfresh/utilities/distribution.py
+++ b/tsfresh/utilities/distribution.py
@@ -355,7 +355,8 @@ class MultiprocessingDistributor(DistributorBaseClass):
     Distributor using a multiprocessing Pool to calculate the jobs in parallel on the local machine.
     """
 
-    def __init__(self, n_workers, disable_progressbar=False, progressbar_title="Feature Extraction", show_warnings=True):
+    def __init__(self, n_workers, disable_progressbar=False, progressbar_title="Feature Extraction",
+                 show_warnings=True):
         """
         Creates a new MultiprocessingDistributor instance
 


### PR DESCRIPTION
On Windows, multiprocessing creates new environments, and thus state of warnings module must be initialized by all workers.
Fix #518.
Fix #559.
May also help with #557 and #604.

Remove a pandas warning about result.columns.contains("value").

Add show_warnings option to select_features and extract_relevant_features.

Replace _logger.warning() calls by warnings.warn() so that warnings are disabled when warnings.simplefilter("ignore") has been called.

These warnings are annoying inside Jupyter notebooks, they produce lots of output and cause trouble.

Also add this option in calculate_relevance_table, and prints a single warning with the list of constant features instead of lots of warnings.