### PR TITLE
Add "autolag" parameter to augmented_dickey_fuller()

### DIFF
--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -301,6 +301,11 @@ class FeatureCalculationTestCase(TestCase):
         for index, val in res_value_error:
             self.assertIsNaN(val)
 
+        # Should return NaN if "attr" is unknown
+        res_attr_error = augmented_dickey_fuller(x=x, param=[{"autolag": "AIC", "attr": ""}])
+        for index, val in res_attr_error:
+            self.assertIsNaN(val)
+
     def test_abs_energy(self):
         self.assertEqualOnAllArrayTypes(abs_energy, [1, 1, 1], 3)
         self.assertEqualOnAllArrayTypes(abs_energy, [1, 2, 3], 14)

--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -251,14 +251,22 @@ class FeatureCalculationTestCase(TestCase):
         # H0 is true
         np.random.seed(seed=42)
         x = np.cumsum(np.random.uniform(size=100))
-        param = [{"attr": "teststat"}, {"attr": "pvalue"}, {"attr": "usedlag"}]
-        expected_index = ['attr_"teststat"', 'attr_"pvalue"', 'attr_"usedlag"']
+        param = [
+            {"autolag": "BIC", "attr": "teststat"},
+            {"autolag": "BIC", "attr": "pvalue"},
+            {"autolag": "BIC", "attr": "usedlag"}
+        ]
+        expected_index = [
+            'autolag_"BIC"__attr_"teststat"',
+            'autolag_"BIC"__attr_"pvalue"',
+            'autolag_"BIC"__attr_"usedlag"',
+        ]
 
         res = augmented_dickey_fuller(x=x, param=param)
         res = pd.Series(dict(res))
         self.assertCountEqual(list(res.index), expected_index)
-        self.assertGreater(res['attr_"pvalue"'], 0.10)
-        self.assertEqual(res['attr_"usedlag"'], 0)
+        self.assertGreater(res['autolag_"BIC"__attr_"pvalue"'], 0.10)
+        self.assertEqual(res['autolag_"BIC"__attr_"usedlag"'], 0)
 
         # H0 should be rejected for AR(1) model with x_{t} = 1/2 x_{t-1} + e_{t}
         np.random.seed(seed=42)
@@ -268,14 +276,22 @@ class FeatureCalculationTestCase(TestCase):
         x[0] = 100
         for i in range(1, m):
             x[i] = x[i - 1] * 0.5 + e[i]
-        param = [{"attr": "teststat"}, {"attr": "pvalue"}, {"attr": "usedlag"}]
-        expected_index = ['attr_"teststat"', 'attr_"pvalue"', 'attr_"usedlag"']
+        param = [
+            {"autolag": "AIC", "attr": "teststat"},
+            {"autolag": "AIC", "attr": "pvalue"},
+            {"autolag": "AIC", "attr": "usedlag"}
+        ]
+        expected_index = [
+            'autolag_"AIC"__attr_"teststat"',
+            'autolag_"AIC"__attr_"pvalue"',
+            'autolag_"AIC"__attr_"usedlag"',
+        ]
 
         res = augmented_dickey_fuller(x=x, param=param)
         res = pd.Series(dict(res))
         self.assertCountEqual(list(res.index), expected_index)
-        self.assertLessEqual(res['attr_"pvalue"'], 0.05)
-        self.assertEqual(res['attr_"usedlag"'], 0)
+        self.assertLessEqual(res['autolag_"AIC"__attr_"pvalue"'], 0.05)
+        self.assertEqual(res['autolag_"AIC"__attr_"usedlag"'], 0)
 
         # Check if LinAlgError and ValueError are catched
         res_linalg_error = augmented_dickey_fuller(x=np.repeat(np.nan, 100), param=param)


### PR DESCRIPTION
The result of Augumented Dickey-Fuller test deeply depends on how we
choose the lag parameter. StatsModels' adfuller() function provides
several criteria for that selection (AIC, BIC and t-stats etc).

This makes it a parameter, and enables users to tweak the lag selection
according to their preference.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>