### PR TITLE
Add a versioned dependency on statsmodels for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ install:
   # need to downgrade tornado manually
   - "[ \"$SCIPY\" = latest ] || [ -z \"$SCIPY\" ] || pip install tornado==4.5.3"
   - "[ \"$SCIPY\" = latest ] && pip install --upgrade scipy || [ -z \"$SCIPY\" ] || pip install scipy==$SCIPY"
-  # recent dask requires fsspec to load data from disk
-  - "[ \"$DASK\" = latest ] && pip install fsspec || true"
   # Print out the pip versions for debugging
   - pip list
   # Only use two cores
@@ -94,4 +92,3 @@ jobs:
     - python: 3.8
   # Make sure to not wait for Python 3.8
   fast_finish: true
-      

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,14 @@ install:
   - "[ \"$NUMPY\" = latest ] && pip install --upgrade numpy || [ -z \"$NUMPY\" ] || pip install numpy==$NUMPY"
   - "[ \"$PANDAS\" = latest ] && pip install --upgrade pandas || [ -z \"$PANDAS\" ] || pip install pandas==$PANDAS"
   - "[ \"$SCIKITLEARN\" = latest ] && pip install --upgrade scikit-learn || [ -z \"$SCIKITLEARN\" ] || pip install scikit-learn==$SCIKITLEARN"
+  - "[ \"$STATSMODELS\" = latest ] && pip install --upgrade statsmodels || [ -z \"$STATSMODELS\" ] || pip install statsmodels==$STATSMODELS"
   - "[ \"$DASK\" = latest ] && pip install --upgrade dask || [ -z \"$DASK\" ] || pip install dask==$DASK"
   - "[ \"$DISTRIBUTED\" = latest ] && pip install --upgrade distributed || [ -z \"$DISTRIBUTED\" ] || pip install distributed==$DISTRIBUTED"
   # need to downgrade tornado manually
   - "[ \"$SCIPY\" = latest ] || [ -z \"$SCIPY\" ] || pip install tornado==4.5.3"
   - "[ \"$SCIPY\" = latest ] && pip install --upgrade scipy || [ -z \"$SCIPY\" ] || pip install scipy==$SCIPY"
+  # recent dask requires fsspec to load data from disk
+  - "[ \"$DASK\" = latest ] && pip install fsspec || true"
   # Print out the pip versions for debugging
   - pip list
   # Only use two cores
@@ -47,30 +50,30 @@ jobs:
   include:
     # First stage: tests
     - stage: Run tests
-      env: NUMPY="latest" PANDAS="latest" SCIKITLEARN="latest" DASK="latest" DISTRIBUTED="latest" SCIPY="latest"
+      env: NUMPY="latest" PANDAS="latest" SCIKITLEARN="latest" DASK="latest" DISTRIBUTED="latest" SCIPY="latest" STATSMODELS="latest"
       python: 3.8
 
-    - env: NUMPY="latest" PANDAS="latest" SCIKITLEARN="latest" DASK="latest" DISTRIBUTED="latest" SCIPY="latest" PYTEST_ADDOPTS="-c setup.cfg"
+    - env: NUMPY="latest" PANDAS="latest" SCIKITLEARN="latest" DASK="latest" DISTRIBUTED="latest" SCIPY="latest" STATSMODELS="latest" PYTEST_ADDOPTS="-c setup.cfg"
       python: 3.7
       # We only run coverage tests here (we also set a different setup.cfg script here)
       after_success:
         - coveralls
 
-    - env: NUMPY="latest" PANDAS="latest" SCIKITLEARN="latest" DASK="latest" DISTRIBUTED="latest" SCIPY="latest"
+    - env: NUMPY="latest" PANDAS="latest" SCIKITLEARN="latest" DASK="latest" DISTRIBUTED="latest" SCIPY="latest" STATSMODELS="latest"
       python: 3.6
 
-    - env: NUMPY="latest" PANDAS="latest" SCIKITLEARN="latest" DASK="latest" DISTRIBUTED="latest" SCIPY="latest"
+    - env: NUMPY="latest" PANDAS="latest" SCIKITLEARN="latest" DASK="latest" DISTRIBUTED="latest" SCIPY="latest" STATSMODELS="latest"
       # newest pandas (>= 0.25) requires python >= 3.5.3
       python: 3.5.3
 
-    - env: NUMPY="1.15.1" PANDAS="0.23.2" SCIKITLEARN="0.19.2" DASK="0.16.1" DISTRIBUTED="1.18.3" SCIPY="1.2.0"
+    - env: NUMPY="1.15.1" PANDAS="0.23.2" SCIKITLEARN="0.19.2" DASK="0.16.1" DISTRIBUTED="1.18.3" SCIPY="1.2.0" STATSMODELS="0.9.0"
       # python 3.7 requires pandas >= 0.23.2
       python: 3.7
 
-    - env: NUMPY="1.12.0" PANDAS="0.20.3" SCIKITLEARN="0.19.0" DASK="0.15.2" DISTRIBUTED="1.18.3" SCIPY="1.2.0"
+    - env: NUMPY="1.12.0" PANDAS="0.20.3" SCIKITLEARN="0.19.0" DASK="0.15.2" DISTRIBUTED="1.18.3" SCIPY="1.2.0" STATSMODELS="0.9.0"
       python: 3.6
 
-    - env: NUMPY="1.12.0" PANDAS="0.20.3" SCIKITLEARN="0.19.0" DASK="0.15.2" DISTRIBUTED="1.18.3" SCIPY="1.2.0"
+    - env: NUMPY="1.12.0" PANDAS="0.20.3" SCIKITLEARN="0.19.0" DASK="0.15.2" DISTRIBUTED="1.18.3" SCIPY="1.2.0" STATSMODELS="0.9.0"
       python: 3.5.3
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ statsmodels>=0.8.0
 patsy>=0.4.1
 scikit-learn>=0.19.0
 tqdm>=4.10.0
-dask>=0.15.2
+dask[dataframe]>=0.15.2
 distributed>=1.18.3

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -1295,7 +1295,6 @@ def ar_coefficient(x, param):
     calculated_ar_params = {}
 
     x_as_list = list(x)
-    calculated_AR = AR(x_as_list)
 
     res = {}
 
@@ -1307,6 +1306,7 @@ def ar_coefficient(x, param):
 
         if k not in calculated_ar_params:
             try:
+                calculated_AR = AR(x_as_list)
                 calculated_ar_params[k] = calculated_AR.fit(maxlag=k, solver="mle").params
             except (LinAlgError, ValueError):
                 calculated_ar_params[k] = [np.NaN] * k


### PR DESCRIPTION
New statsmodels 0.11.0 package seems to cause compatibility issues with older packages:

    RuntimeError: module compiled against API version 0xc but this version of numpy is 0xa

We depend on statsmodels 0.9.0 because this is the first version available on conda
for Python 3.5, 3.6 and 3.7, but users can use 0.8.0 as well.

Fix `ar_coefficient method` with newest statsmodels, `AR` class is now immutable.

Also latest dask requires fsspec in order to read data from disk.