### PR TITLE
Added variation coefficient

### DIFF
--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -371,10 +371,10 @@ class FeatureCalculationTestCase(TestCase):
         self.assertIsNanOnAllArrayTypes(standard_deviation, [])
 
     def test_variation_coefficient(self):
-        self.assertAlmostEqualOnAllArrayTypes(variation_coefficient, [1, 1, -1, -1], np.nan)
+        self.assertIsNanOnAllArrayTypes(variation_coefficient, [1, 1, -1, -1],)
         self.assertAlmostEqualOnAllArrayTypes(variation_coefficient, [1, 2, -3, -1], -7.681145747868608)
         self.assertAlmostEqualOnAllArrayTypes(variation_coefficient, [1, 2, 4, -1], 1.2018504251546631)
-        self.assertIsNanOnAllArrayTypes(variation_coefficient, np.nan)
+        self.assertIsNanOnAllArrayTypes(variation_coefficient, [])
 
     def test_variance(self):
         self.assertAlmostEqualOnAllArrayTypes(variance, [1, 1, -1, -1], 1)

--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -370,6 +370,12 @@ class FeatureCalculationTestCase(TestCase):
         self.assertAlmostEqualOnAllArrayTypes(standard_deviation, [1, 2, -2, -1], 1.58113883008)
         self.assertIsNanOnAllArrayTypes(standard_deviation, [])
 
+    def test_variation_coefficient(self):
+        self.assertAlmostEqualOnAllArrayTypes(variation_coefficient, [1, 1, -1, -1], np.nan)
+        self.assertAlmostEqualOnAllArrayTypes(variation_coefficient, [1, 2, -3, -1], -7.681145747868608)
+        self.assertAlmostEqualOnAllArrayTypes(variation_coefficient, [1, 2, 4, -1], 1.2018504251546631)
+        self.assertIsNanOnAllArrayTypes(variation_coefficient, np.nan)
+
     def test_variance(self):
         self.assertAlmostEqualOnAllArrayTypes(variance, [1, 1, -1, -1], 1)
         self.assertAlmostEqualOnAllArrayTypes(variance, [1, 2, -2, -1], 2.5)

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -634,7 +634,7 @@ def standard_deviation(x):
 @set_property("fctype", "simple")
 def variation_coefficient(x):
     """
-    Returns the variation coefficient of x
+    Returns the variation coefficient (standard error / mean, give relative value of variation around mean) of x.
 
     :param x: the time series to calculate the feature of
     :type x: numpy.ndarray
@@ -643,7 +643,7 @@ def variation_coefficient(x):
     """
     mean = np.mean(x)
     if mean != 0:
-        return np.std(x) / np.mean(x)
+        return np.std(x) / mean
     else:
         return np.nan
 

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -630,6 +630,23 @@ def standard_deviation(x):
     """
     return np.std(x)
 
+@set_property("fctype", "simple")
+@set_property("minimal", True)
+def variation_coefficient(x):
+    """
+    Returns the variation coefficient of x
+
+    :param x: the time series to calculate the feature of
+    :type x: numpy.ndarray
+    :return: the value of this feature
+    :return type: float
+    """
+    mean = np.mean(x)
+    if mean != 0:
+        return np.std(x) / np.mean(x)
+    else:
+        return np.nan
+
 
 @set_property("fctype", "simple")
 @set_property("minimal", True)

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -630,6 +630,7 @@ def standard_deviation(x):
     """
     return np.std(x)
 
+
 @set_property("fctype", "simple")
 @set_property("minimal", True)
 def variation_coefficient(x):

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -632,7 +632,6 @@ def standard_deviation(x):
 
 
 @set_property("fctype", "simple")
-@set_property("minimal", True)
 def variation_coefficient(x):
     """
     Returns the variation coefficient of x


### PR DESCRIPTION
Added coefficient of variation to have a relative value for standard deviation.

variation_coefficient = np.std(X) / np.mean(X)

Main problem is that we cannot compute the variable when the mean is 0, I chose to return missing value in this case.