### PR TITLE
Better/Correct/Faster rolling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@ Unreleased
       The feature names consist of a sorted list of all parameters now.
       That used to be true for all non-combiner features, and is now also true for combiner features.
       If you relied on the actual feature name, this is a breaking change.
+    - Change the id after the rolling (#668)
+      Now, the old id of your data is still kept. Additionally, we improved the way
+      dataframes without a time column are rolled and how the new sub-time series
+      are named.
+      Also, the documentation was improved a lot.
 - Added Features
     - Added variation coefficient (#654)
     - Added the datetimeindex explanation from the notebook to the docs (#661)

--- a/docs/text/forecasting.rst
+++ b/docs/text/forecasting.rst
@@ -32,7 +32,7 @@ The following image illustrates the process:
 
 
 Another example can be found in streaming data, e.g. in Industry 4.0 applications.
-Here you typically get one new data row at a time and use this to for example predict machine failures. To train your model,
+Here you typically get one new data row at a time and use this to, for example, predict machine failures. To train your model,
 you could act as if you would stream the data, by feeding your classifier the data after one time step,
 the data after the first two time steps etc.
 
@@ -45,14 +45,7 @@ Let's walk through an example to see how it works:
 The rolling mechanism
 ---------------------
 
-The rolling mechanism takes a time series :math:`x` with its data rows :math:`[x_1, x_2, x_3, ..., x_n]`
-and creates :math:`n` new time series :math:`\hat x^k`, each of them with a different consecutive part
-of :math:`x`:
-
-.. math::
-    \hat x^k = [x_k, x_{k-1}, x_{k-2}, ..., x_1]
-
-To see what this does in real-world applications, we look into the following example flat DataFrame in tsfresh format
+We look into the following example flat DataFrame in tsfresh format
 
 +----+------+----+----+
 | id | time | x  | y  |
@@ -88,6 +81,7 @@ If you want to follow along, here is the python code to generate this data:
 Now, we can use :func:`tsfresh.utilities.dataframe_functions.roll_time_series` to get consecutive sub-time series.
 You could think of having a window sliding over your time series data and extracting out every data you can see through this window.
 There are three parameters to tune the window:
+
 * `rolling_direction`: if you want to slide in positive (increasing sort) or negative (decreasing sort) direction. Default is positive.
 * `max_timeshift` defines, how large the window size will grow. This means the extracted time series will have at maximum `max_timeshift + 1` steps in the past (or future). Default is infinite.
 * `min_timeshift` defines the minimal size. Defaults to 0.

--- a/docs/text/forecasting.rst
+++ b/docs/text/forecasting.rst
@@ -20,8 +20,7 @@ The rolling utilities implemented in `tsfresh` help you in this process of resha
 Please note that "time" does not necessarily mean clock time here.
 The "sort" column of a DataFrame in the supported :ref:`data-formats-label` gives a sequential state to the
 individual measurements.
-In the case of time series this can be the *time* dimension while in the case of spectra the
-order is given by the *wavelength* or *frequency* dimensions.
+In the case of time series this can be the *time* dimension while in other cases, this can be a location, a frequency. etc.
 
 The following image illustrates the process:
 
@@ -64,7 +63,7 @@ We look into the following example flat DataFrame in tsfresh format
 +----+------+----+----+
 
 where you have measured the values from two sensors x and y for two different entities (id 1 and 2) in 4 or 2 time
-steps (t1 to t9).
+steps (1 to 9).
 
 If you want to follow along, here is the python code to generate this data:
 
@@ -82,9 +81,9 @@ Now, we can use :func:`tsfresh.utilities.dataframe_functions.roll_time_series` t
 You could think of having a window sliding over your time series data and extracting out every data you can see through this window.
 There are three parameters to tune the window:
 
-* `rolling_direction`: if you want to slide in positive (increasing sort) or negative (decreasing sort) direction. Default is positive.
-* `max_timeshift` defines, how large the window size will grow. This means the extracted time series will have at maximum `max_timeshift + 1` steps in the past (or future). Default is infinite.
-* `min_timeshift` defines the minimal size. Defaults to 0.
+* `max_timeshift` defines, how large the window size will grow. This means the extracted time series will have at maximum `max_timeshift + 1` steps in the past (or future).
+* `min_timeshift` defines the minimal size.
+* Advanced: `rolling_direction`: if you want to slide in positive (increasing sort) or negative (decreasing sort) direction. You barely need negative direction, so you probably not want to change the default.
 
 The column parameters are the same as in the usual :ref:`data-formats-label`.
 

--- a/docs/text/forecasting.rst
+++ b/docs/text/forecasting.rst
@@ -51,11 +51,11 @@ We look into the following example flat DataFrame in tsfresh format
 +====+======+====+====+
 | 1  |  1   | 1  | 5  |
 +----+------+----+----+
-| 1  |  2   | 2	 | 6  |
+| 1  |  2   | 2  | 6  |
 +----+------+----+----+
-| 1  |  3   | 3	 | 7  |
+| 1  |  3   | 3  | 7  |
 +----+------+----+----+
-| 1  |  4   | 4	 | 8  |
+| 1  |  4   | 4  | 8  |
 +----+------+----+----+
 | 2  |  8   | 10 | 12 |
 +----+------+----+----+
@@ -63,7 +63,7 @@ We look into the following example flat DataFrame in tsfresh format
 +----+------+----+----+
 
 where you have measured the values from two sensors x and y for two different entities (id 1 and 2) in 4 or 2 time
-steps (1 to 9).
+steps (1, 2, 3, 4, 8, 9).
 
 If you want to follow along, here is the python code to generate this data:
 
@@ -174,6 +174,8 @@ You will end up with features generated for each of the parts above, which you c
 +------------------+----------------+-----------------------------+-----+
 | id=2,timeshift=9 |          221.0 |                         1.0 | ... |
 +------------------+----------------+-----------------------------+-----+
+
+The features for e.g. ``id=1,timeshift=3`` are extracted using the data up to and including ``t=3`` (so ``t=1``, ``t=2`` and ``t=3``).
 
 If you want to train for a forecasting, `tsfresh` also offers the function :func:`tsfresh.utilities.dataframe_functions.make_forecasting_frame`, which will also help you match the target vector properly.
 This process is also visualized by the following figure.

--- a/docs/text/forecasting.rst
+++ b/docs/text/forecasting.rst
@@ -1,22 +1,27 @@
 .. _forecasting-label:
 
-Time series forecasting
-=======================
+Time series forecasting/Rolling
+===============================
 
 Features that are extracted with *tsfresh* can be used for many different tasks, such as time series classification,
 compression or forecasting.
 This section explains how one can use the features for time series forecasting tasks.
 
-The "sort" column of a DataFrame in the supported :ref:`data-formats-label` gives a sequential state to the
-individual measurements. In the case of time series this can be the *time* dimension while in the case of spectra the
-order is given by the *wavelength* or *frequency* dimensions.
-We can exploit this sequence to generate more input data out of a single time series, by *rolling* over the data.
-
 Lets say you have the price of a certain stock, e.g. Apple, for 100 time steps.
 Now, you want to build a feature-based model to forecast future prices of the Apple stock.
-So you will have to extract features in every time step of the original time series while looking at
-a certain number of past values.
-A rolling mechanism will give you the sub time series of last *m* time steps to construct the features.
+You could remove the last price value (of today) and extract features from the time series until today to predict the price of today.
+But this would only give you a single example to train.
+However, you can repeat this process: for every day in your stock price time series, remove the current value, extract features for the time until this value and train to predict the value of the day (which you removed).
+In `tsfresh`, this is called *rolling*.
+
+Rolling is a way, to turn a single time series into multiple time series, each of them ending (or starting, depending on the roll direction) one time step later than the one before.
+The rolling utilities implemented in `tsfresh` help you in this process of reshaping (and rolling) your data into a form, so that you can apply the usual :func:`tsfresh.extract_features` method.
+
+Please note that "time" does not necessarily mean clock time here.
+The "sort" column of a DataFrame in the supported :ref:`data-formats-label` gives a sequential state to the
+individual measurements.
+In the case of time series this can be the *time* dimension while in the case of spectra the
+order is given by the *wavelength* or *frequency* dimensions.
 
 The following image illustrates the process:
 
@@ -26,20 +31,16 @@ The following image illustrates the process:
    :align: center
 
 
-
-So, we move the window that extract the features and then predict the next time step (which was not used to extract features) forward.
-In the above image, the window moves from left to right.
-
 Another example can be found in streaming data, e.g. in Industry 4.0 applications.
 Here you typically get one new data row at a time and use this to for example predict machine failures. To train your model,
 you could act as if you would stream the data, by feeding your classifier the data after one time step,
 the data after the first two time steps etc.
 
-Both examples imply, that you extract the features not only on the full data set, but also
-on all temporal coherent subsets of data, which is the process of *rolling*. In tsfresh, this is implemented in the
-function :func:`tsfresh.utilities.dataframe_functions.roll_time_series`.
+In tsfresh, rolling is implemented via the helper function :func:`tsfresh.utilities.dataframe_functions.roll_time_series`.
 Further, we provide the :func:`tsfresh.utilities.dataframe_functions.make_forecasting_frame` method as a convenient
 wrapper to fast construct the container and target vector for a given sequence.
+
+Let's walk through an example to see how it works:
 
 The rolling mechanism
 ---------------------
@@ -56,260 +57,183 @@ To see what this does in real-world applications, we look into the following exa
 +----+------+----+----+
 | id | time | x  | y  |
 +====+======+====+====+
-| 1  | t1   | 1  | 5  |
+| 1  |  1   | 1  | 5  |
 +----+------+----+----+
-| 1  | t2   | 2	 | 6  |
+| 1  |  2   | 2	 | 6  |
 +----+------+----+----+
-| 1  | t3   | 3	 | 7  |
+| 1  |  3   | 3	 | 7  |
 +----+------+----+----+
-| 1  | t4   | 4	 | 8  |
+| 1  |  4   | 4	 | 8  |
 +----+------+----+----+
-| 2  | t8   | 10 | 12 |
+| 2  |  8   | 10 | 12 |
 +----+------+----+----+
-| 2  | t9   | 11 | 13 |
+| 2  |  9   | 11 | 13 |
 +----+------+----+----+
 
 where you have measured the values from two sensors x and y for two different entities (id 1 and 2) in 4 or 2 time
 steps (t1 to t9).
 
+If you want to follow along, here is the python code to generate this data:
+
+.. code:: python
+
+   import pandas as pd
+   df = pd.DataFrame({
+      "id": [1, 1, 1, 1, 2, 2],
+      "time": [1, 2, 3, 4, 8, 9],
+      "x": [1, 2, 3, 4, 10, 11],
+      "y": [5, 6, 7, 8, 12, 13],
+   })
+
 Now, we can use :func:`tsfresh.utilities.dataframe_functions.roll_time_series` to get consecutive sub-time series.
-E.g. if you set `rolling` to 0, the feature extraction works on the original time series without any rolling.
+You could think of having a window sliding over your time series data and extracting out every data you can see through this window.
+There are three parameters to tune the window:
+* `rolling_direction`: if you want to slide in positive (increasing sort) or negative (decreasing sort) direction. Default is positive.
+* `max_timeshift` defines, how large the window size will grow. This means the extracted time series will have at maximum `max_timeshift + 1` steps in the past (or future). Default is infinite.
+* `min_timeshift` defines the minimal size. Defaults to 0.
 
-So it extracts 2 set of features,
+The column parameters are the same as in the usual :ref:`data-formats-label`.
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 1  | t1   | 1  | 5  |
-+----+------+----+----+
-| 1  | t2   | 2	 | 6  |
-+----+------+----+----+
-| 1  | t3   | 3	 | 7  |
-+----+------+----+----+
-| 1  | t4   | 4	 | 8  |
-+----+------+----+----+
+Let's see what will happen with our data sample:
 
-and
+.. code:: python
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 2  | t8   | 10 | 12 |
-+----+------+----+----+
-| 2  | t9   | 11 | 13 |
-+----+------+----+----+
+   from tsfresh.utilities.dataframe_functions import roll_time_series
+   df_rolled = roll_time_series(df, column_id="id", column_sort="time")
 
-If you set rolling to 1, the feature extraction works with all of the following time series:
+The new data set consists only of values from the old data set, but with new indices.
+If you group by index, you will end up with the following parts:
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 1  | t1   | 1  | 5  |
-+----+------+----+----+
++-----------------+-------+---+----+
+|id               | time  | x |  y |
++=================+=======+===+====+
+|id=1,timeshift=1 |    1  | 1 |  5 |
++-----------------+-------+---+----+
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 1  | t1   | 1  | 5  |
-+----+------+----+----+
-| 1  | t2   | 2  | 6  |
-+----+------+----+----+
++-----------------+-------+---+----+
+|id               | time  | x |  y |
++=================+=======+===+====+
+|id=1,timeshift=2 |    1  | 1 |  5 |
++-----------------+-------+---+----+
+|id=1,timeshift=2 |    2  | 2 |  6 |
++-----------------+-------+---+----+
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 1  | t1   | 1  | 5  |
-+----+------+----+----+
-| 1  | t2   | 2  | 6  |
-+----+------+----+----+
-| 1  | t3   | 3  | 7  |
-+----+------+----+----+
-| 2  | t8   | 10 | 12 |
-+----+------+----+----+
++-----------------+-------+---+----+
+|id               | time  | x |  y |
++=================+=======+===+====+
+|id=1,timeshift=3 |    1  | 1 |  5 |
++-----------------+-------+---+----+
+|id=1,timeshift=3 |    2  | 2 |  6 |
++-----------------+-------+---+----+
+|id=1,timeshift=3 |    3  | 3 |  7 |
++-----------------+-------+---+----+
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 1  | t1   | 1  | 5  |
-+----+------+----+----+
-| 1  | t2   | 2  | 6  |
-+----+------+----+----+
-| 1  | t3   | 3  | 7  |
-+----+------+----+----+
-| 1  | t4   | 4  | 8  |
-+----+------+----+----+
-| 2  | t8   | 10 | 12 |
-+----+------+----+----+
-| 2  | t9   | 11 | 13 |
-+----+------+----+----+
++-----------------+-------+---+----+
+|id               | time  | x |  y |
++=================+=======+===+====+
+|id=1,timeshift=4 |    1  | 1 |  5 |
++-----------------+-------+---+----+
+|id=1,timeshift=4 |    2  | 2 |  6 |
++-----------------+-------+---+----+
+|id=1,timeshift=4 |    3  | 3 |  7 |
++-----------------+-------+---+----+
+|id=1,timeshift=4 |    4  | 4 |  8 |
++-----------------+-------+---+----+
 
-If you set rolling to -1, you end up with features for the time series, rolled in the other direction
++-----------------+-------+---+----+
+|id               | time  | x |  y |
++=================+=======+===+====+
+|id=2,timeshift=8 |    8  |10 | 12 |
++-----------------+-------+---+----+
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 1  | t4   | 4  | 8  |
-+----+------+----+----+
++-----------------+-------+---+----+
+|id               | time  | x |  y |
++=================+=======+===+====+
+|id=2,timeshift=9 |    8  |10 | 12 |
++-----------------+-------+---+----+
+|id=2,timeshift=9 |    9  |11 | 13 |
++-----------------+-------+---+----+
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 1  | t3   | 3  | 7  |
-+----+------+----+----+
-| 1  | t4   | 4  | 8  |
-+----+------+----+----+
+Each of those parts can now be treated independently.
+For example, you could run the usual feature extraction on them:
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 1  | t2   | 2  | 6  |
-+----+------+----+----+
-| 1  | t3   | 3  | 7  |
-+----+------+----+----+
-| 1  | t4   | 4  | 8  |
-+----+------+----+----+
-| 2  | t9   | 11 | 13 |
-+----+------+----+----+
+.. code:: python
 
-+----+------+----+----+
-| id | time | x  | y  |
-+====+======+====+====+
-| 1  | t1   | 1  | 5  |
-+----+------+----+----+
-| 1  | t2   | 2  | 6  |
-+----+------+----+----+
-| 1  | t3   | 3  | 7  |
-+----+------+----+----+
-| 1  | t4   | 4  | 8  |
-+----+------+----+----+
-| 2  | t8   | 10 | 12 |
-+----+------+----+----+
-| 2  | t9   | 11 | 13 |
-+----+------+----+----+
+   from tsfresh import extract_features
+   df_features = extract_features(df_rolled, column_id="id", column_sort="time")
 
-We only gave an example for the flat DataFrame format, but rolling actually works on all 3 :ref:`data-formats-label`
-that are supported by tsfresh.
+You will end up with features generated for each of the parts above, which you can then use for training your forecasting model.
 
++------------------+----------------+-----------------------------+-----+
+| variable         |  x__abs_energy |  x__absolute_sum_of_changes | ... |
++==================+================+=============================+=====+
+| id               |                |                             | ... |
++------------------+----------------+-----------------------------+-----+
+| id=1,timeshift=1 |            1.0 |                         0.0 | ... |
++------------------+----------------+-----------------------------+-----+
+| id=1,timeshift=2 |            5.0 |                         1.0 | ... |
++------------------+----------------+-----------------------------+-----+
+| id=1,timeshift=3 |           14.0 |                         2.0 | ... |
++------------------+----------------+-----------------------------+-----+
+| id=1,timeshift=4 |           30.0 |                         3.0 | ... |
++------------------+----------------+-----------------------------+-----+
+| id=2,timeshift=8 |          100.0 |                         0.0 | ... |
++------------------+----------------+-----------------------------+-----+
+| id=2,timeshift=9 |          221.0 |                         1.0 | ... |
++------------------+----------------+-----------------------------+-----+
+
+If you want to train for a forecasting, `tsfresh` also offers the function :func:`tsfresh.utilities.dataframe_functions.make_forecasting_frame`, which will also help you match the target vector properly.
 This process is also visualized by the following figure.
 It shows how the purple, rolled sub-timeseries are used as base for the construction of the feature matrix *X*
-(after calculation of the features by *f*).
+(if *f* is the `extract_features` function).
 The green data points need to be predicted by the model and are used as rows in the target vector *y*.
+Be aware that this only works for a one-dimensional time series of a single `id` and `kind`.
 
 .. image:: ../images/rolling_mechanism_2.png
    :scale: 100 %
    :alt: The rolling mechanism
    :align: center
 
-
-
 Parameters and Implementation Notes
 -----------------------------------
 
 The above example demonstrates the overall rolling mechanism, which creates new time series.
-Now we discuss the naming convention for such new time series:
+Now we discuss the naming convention for such new time series.
 
-For identifying every subsequence, tsfresh uses the time stamp of the point that will be predicted as new "id".
-The above example with rolling set to 1 yields the following sub-time series:
+For identifying every subsequence, `tsfresh` uses the time stamp of the point that will be predicted together with the old identifier as "id".
+For positive rolling, this `timeshift` is the last time stamp in the subsequence.
+For negative rolling, it is the first one, for example the above dataframe rolled in negative direction gives us:
 
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t1        | t1   | 1  | 5  |
-+-----------+------+----+----+
++------------------+------+----+----+
+|id                | time |  x |  y |
++==================+======+====+====+
+|id=1,timeshift=1  |    1 |  1 |  5 |
++------------------+------+----+----+
+|id=1,timeshift=1  |    2 |  2 |  6 |
++------------------+------+----+----+
+|id=1,timeshift=1  |    3 |  3 |  7 |
++------------------+------+----+----+
+|id=1,timeshift=1  |    4 |  4 |  8 |
++------------------+------+----+----+
+|id=1,timeshift=2  |    2 |  2 |  6 |
++------------------+------+----+----+
+|id=1,timeshift=2  |    3 |  3 |  7 |
++------------------+------+----+----+
+|id=1,timeshift=2  |    4 |  4 |  8 |
++------------------+------+----+----+
+|id=1,timeshift=3  |    3 |  3 |  7 |
++------------------+------+----+----+
+|id=1,timeshift=3  |    4 |  4 |  8 |
++------------------+------+----+----+
+|id=1,timeshift=4  |    4 |  4 |  8 |
++------------------+------+----+----+
+|id=2,timeshift=8  |    8 | 10 | 12 |
++------------------+------+----+----+
+|id=2,timeshift=8  |    9 | 11 | 13 |
++------------------+------+----+----+
+|id=2,timeshift=9  |    9 | 11 | 13 |
++------------------+------+----+----+
 
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t2        | t1   | 1  | 5  |
-+-----------+------+----+----+
-| t2        | t2   | 2  | 6  |
-+-----------+------+----+----+
+which you could use to predict the current value using the future time series values (if that makes sense in your case).
 
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t3        | t1   | 1  | 5  |
-+-----------+------+----+----+
-| t3        | t2   | 2  | 6  |
-+-----------+------+----+----+
-| t3        | t3   | 3  | 7  |
-+-----------+------+----+----+
-
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t4        | t1   | 1  | 5  |
-+-----------+------+----+----+
-| t4        | t2   | 2  | 6  |
-+-----------+------+----+----+
-| t4        | t3   | 3  | 7  |
-+-----------+------+----+----+
-| t4        | t4   | 4  | 8  |
-+-----------+------+----+----+
-
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t8        | t8   | 10 | 12 |
-+-----------+------+----+----+
-
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t9        | t8   | 10 | 12 |
-+-----------+------+----+----+
-| t9        | t9   | 11 | 13 |
-+-----------+------+----+----+
-
-The new id is the time stamp where the shift ended.
-So above, every table represents a sub-time series.
-The higher the shift value, the more steps the time series was moved into the specified direction (into the past in
-this example).
-
-If you want to limit how far the time series shall be shifted into the specified direction, you can set the
-*max_timeshift* parameter to the maximum time steps to be shifted.
-In our example, setting *max_timeshift* to 1 yields the following result (setting it to 0 will create all possible shifts):
-
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t1        | t1   | 1  | 5  |
-+-----------+------+----+----+
-
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t2        | t1   | 1  | 5  |
-+-----------+------+----+----+
-| t2        | t2   | 2  | 6  |
-+-----------+------+----+----+
-
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t3        | t2   | 2  | 6  |
-+-----------+------+----+----+
-| t3        | t3   | 3  | 7  |
-+-----------+------+----+----+
-
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t4        | t3   | 3  | 7  |
-+-----------+------+----+----+
-| t4        | t4   | 4  | 8  |
-+-----------+------+----+----+
-
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t8        | t8   | 10 | 12 |
-+-----------+------+----+----+
-
-+-----------+------+----+----+
-| id        | time | x  | y  |
-+===========+======+====+====+
-| t9        | t8   | 10 | 12 |
-+-----------+------+----+----+
-| t9        | t9   | 11 | 13 |
-+-----------+------+----+----+
+Choosing a non-default `max_timeshift` or `min_timeshift` would make the extracted sub-time-series smaller or even remove them completely (e.g. with `min_timeshift = 1` the `id=1,timeshift=1` of the positive rolling case would disappear).

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -479,7 +479,6 @@ class RollingTestCase(TestCase):
         self.assertListEqual(list(df["a"].values), correct_values_a)
         self.assertListEqual(list(df["b"].values), correct_values_b)
 
-
         df = dataframe_functions.roll_time_series(df_full, column_id="id", column_sort="time",
                                                   column_kind=None, rolling_direction=-1,
                                                   min_timeshift=2,

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -277,7 +277,21 @@ class RollingTestCase(TestCase):
         4  10  12    20   2
         5  11  13    21   2
         """
-        correct_indices = [0, 1, 1, 2, 2, 2, 3, 3, 3, 3, 20, 21, 21]
+        correct_indices = [
+                'id=1,shift=0',
+                'id=1,shift=1',
+                'id=1,shift=1',
+                'id=1,shift=2',
+                'id=1,shift=2',
+                'id=1,shift=2',
+                'id=1,shift=3',
+                'id=1,shift=3',
+                'id=1,shift=3',
+                'id=1,shift=3',
+                'id=2,shift=0',
+                'id=2,shift=1',
+                'id=2,shift=1'
+            ]
         correct_values_a = [1.0, 1.0, 2.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 4.0, 10.0, 10.0, 11.0]
         correct_values_b = [5.0, 5.0, 6.0, 5.0, 6.0, 7.0, 5.0, 6.0, 7.0, 8.0, 12.0, 12.0, 13.0]
 
@@ -300,7 +314,20 @@ class RollingTestCase(TestCase):
                                                   column_kind=None, rolling_direction=1,
                                                   max_timeshift=2)
 
-        correct_indices = [0, 1, 1, 2, 2, 2, 3, 3, 3, 20, 21, 21]
+        correct_indices = [
+            'id=1,shift=0',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=2',
+            'id=1,shift=2',
+            'id=1,shift=2',
+            'id=1,shift=3',
+            'id=1,shift=3',
+            'id=1,shift=3',
+            'id=2,shift=0',
+            'id=2,shift=1',
+            'id=2,shift=1'
+        ]
         correct_values_a = [1.0, 1.0, 2.0, 1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 10.0, 10.0, 11.0]
         correct_values_b = [5.0, 5.0, 6.0, 5.0, 6.0, 7.0, 6.0, 7.0, 8.0, 12.0, 12.0, 13.0]
 

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -278,19 +278,19 @@ class RollingTestCase(TestCase):
         5  11  13    21   2
         """
         correct_indices = [
-                'id=1,shift=0',
-                'id=1,shift=1',
-                'id=1,shift=1',
-                'id=1,shift=2',
-                'id=1,shift=2',
-                'id=1,shift=2',
-                'id=1,shift=3',
-                'id=1,shift=3',
-                'id=1,shift=3',
-                'id=1,shift=3',
-                'id=2,shift=0',
-                'id=2,shift=1',
-                'id=2,shift=1'
+                'id=1,timeshift=0',
+                'id=1,timeshift=1',
+                'id=1,timeshift=1',
+                'id=1,timeshift=2',
+                'id=1,timeshift=2',
+                'id=1,timeshift=2',
+                'id=1,timeshift=3',
+                'id=1,timeshift=3',
+                'id=1,timeshift=3',
+                'id=1,timeshift=3',
+                'id=2,timeshift=20',
+                'id=2,timeshift=21',
+                'id=2,timeshift=21'
             ]
         correct_values_a = [1.0, 1.0, 2.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 4.0, 10.0, 10.0, 11.0]
         correct_values_b = [5.0, 5.0, 6.0, 5.0, 6.0, 7.0, 5.0, 6.0, 7.0, 8.0, 12.0, 12.0, 13.0]
@@ -315,18 +315,18 @@ class RollingTestCase(TestCase):
                                                   max_timeshift=2)
 
         correct_indices = [
-            'id=1,shift=0',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=2',
-            'id=1,shift=2',
-            'id=1,shift=2',
-            'id=1,shift=3',
-            'id=1,shift=3',
-            'id=1,shift=3',
-            'id=2,shift=0',
-            'id=2,shift=1',
-            'id=2,shift=1'
+            'id=1,timeshift=0',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=3',
+            'id=1,timeshift=3',
+            'id=1,timeshift=3',
+            'id=2,timeshift=20',
+            'id=2,timeshift=21',
+            'id=2,timeshift=21'
         ]
         correct_values_a = [1.0, 1.0, 2.0, 1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 10.0, 10.0, 11.0]
         correct_values_b = [5.0, 5.0, 6.0, 5.0, 6.0, 7.0, 6.0, 7.0, 8.0, 12.0, 12.0, 13.0]
@@ -354,19 +354,19 @@ class RollingTestCase(TestCase):
         """
 
         correct_indices = [
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=2',
-            'id=1,shift=2',
-            'id=1,shift=3',
-            'id=2,shift=0',
-            'id=2,shift=0',
-            'id=2,shift=1'
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=3',
+            'id=2,timeshift=20',
+            'id=2,timeshift=20',
+            'id=2,timeshift=21'
         ]
         correct_values_a = [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 3.0, 4.0, 4.0, 10.0, 11.0, 11.0]
         correct_values_b = [5.0, 6.0, 7.0, 8.0, 6.0, 7.0, 8.0, 7.0, 8.0, 8.0, 12.0, 13.0, 13.0]
@@ -391,16 +391,16 @@ class RollingTestCase(TestCase):
                                                   max_timeshift=1)
 
         correct_indices = [
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=2',
-            'id=1,shift=2',
-            'id=1,shift=3',
-            'id=2,shift=0',
-            'id=2,shift=0',
-            'id=2,shift=1'
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=3',
+            'id=2,timeshift=20',
+            'id=2,timeshift=20',
+            'id=2,timeshift=21'
         ]
         correct_values_a = [1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 10.0, 11.0, 11.0]
         correct_values_b = [5.0, 6.0, 6.0, 7.0, 7.0, 8.0, 8.0, 12.0, 13.0, 13.0]
@@ -414,18 +414,18 @@ class RollingTestCase(TestCase):
                                                   max_timeshift=2)
 
         correct_indices = [
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=2',
-            'id=1,shift=2',
-            'id=1,shift=3',
-            'id=2,shift=0',
-            'id=2,shift=0',
-            'id=2,shift=1'
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=3',
+            'id=2,timeshift=20',
+            'id=2,timeshift=20',
+            'id=2,timeshift=21'
         ]
         correct_values_a = [1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 3.0, 4.0, 4.0, 10.0, 11.0, 11.0]
         correct_values_b = [5.0, 6.0, 7.0, 6.0, 7.0, 8.0, 7.0, 8.0, 8.0, 12.0, 13.0, 13.0]
@@ -439,19 +439,19 @@ class RollingTestCase(TestCase):
                                                   max_timeshift=4)
 
         correct_indices = [
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=2',
-            'id=1,shift=2',
-            'id=1,shift=3',
-            'id=2,shift=0',
-            'id=2,shift=0',
-            'id=2,shift=1'
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=3',
+            'id=2,timeshift=20',
+            'id=2,timeshift=20',
+            'id=2,timeshift=21'
         ]
         correct_values_a = [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 3.0, 4.0, 4.0, 10.0, 11.0, 11.0]
         correct_values_b = [5.0, 6.0, 7.0, 8.0, 6.0, 7.0, 8.0, 7.0, 8.0, 8.0, 12.0, 13.0, 13.0]
@@ -493,12 +493,12 @@ class RollingTestCase(TestCase):
                                                   column_kind="kind", rolling_direction=-1)
 
         correct_indices = (
-            ['id=1,shift=0'] * 2 * 4 +
-            ['id=1,shift=1'] * 2 * 3 +
-            ['id=1,shift=2'] * 2 * 2 +
-            ['id=1,shift=3'] * 2 * 1 +
-            ['id=2,shift=0'] * 2 * 2 +
-            ['id=2,shift=1'] * 2 * 1
+            ['id=1,timeshift=0'] * 2 * 4 +
+            ['id=1,timeshift=1'] * 2 * 3 +
+            ['id=1,timeshift=2'] * 2 * 2 +
+            ['id=1,timeshift=3'] * 2 * 1 +
+            ['id=2,timeshift=20'] * 2 * 2 +
+            ['id=2,timeshift=21'] * 2 * 1
         )
         self.assertListEqual(list(df["id"].values), correct_indices)
 
@@ -534,19 +534,19 @@ class RollingTestCase(TestCase):
         """
 
         correct_indices = [
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=2',
-            'id=1,shift=2',
-            'id=1,shift=3',
-            'id=2,shift=0',
-            'id=2,shift=0',
-            'id=2,shift=1'
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=3',
+            'id=2,timeshift=0',
+            'id=2,timeshift=0',
+            'id=2,timeshift=1'
         ]
         self.assertListEqual(list(df["a"]["id"].values), correct_indices)
 
@@ -584,16 +584,16 @@ class RollingTestCase(TestCase):
         """
 
         correct_indices = [
-            'id=1,shift=0',
-            'id=1,shift=0',
-            'id=1,shift=1',
-            'id=1,shift=1',
-            'id=1,shift=2',
-            'id=1,shift=2',
-            'id=1,shift=3',
-            'id=2,shift=0',
-            'id=2,shift=0',
-            'id=2,shift=1'
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=3',
+            'id=2,timeshift=0',
+            'id=2,timeshift=0',
+            'id=2,timeshift=1'
         ]
 
         self.assertListEqual(list(df["a"]["id"].values), correct_indices)
@@ -831,17 +831,23 @@ class MakeForecastingFrameTestCase(TestCase):
     def test_make_forecasting_frame_list(self):
         df, y = dataframe_functions.make_forecasting_frame(x=range(4), kind="test",
                                                            max_timeshift=1, rolling_direction=1)
-        expected_df = pd.DataFrame({"id": [1, 2, 3], "kind": ["test"] * 3, "value": [0., 1., 2.], "time": [0., 1., 2.]})
+        expected_df = pd.DataFrame({"id": ["id=id,timeshift=1", "id=id,timeshift=2", "id=id,timeshift=3"],
+                                    "kind": ["test"] * 3,
+                                    "value": [0, 1, 2],
+                                    "time": [0, 1, 2]})
 
         expected_y = pd.Series(data=[1, 2, 3], index=[1, 2, 3], name="value")
-        assert_frame_equal(df.sort_index(axis=1), expected_df.sort_index(axis=1))
+        assert_frame_equal(df.sort_index(axis=1).reset_index(drop=True), expected_df.sort_index(axis=1))
         assert_series_equal(y, expected_y)
 
     def test_make_forecasting_frame_range(self):
         df, y = dataframe_functions.make_forecasting_frame(x=np.arange(4), kind="test",
                                                            max_timeshift=1, rolling_direction=1)
-        expected_df = pd.DataFrame({"id": [1, 2, 3], "kind": ["test"] * 3, "value": [0., 1., 2.], "time": [0., 1., 2.]})
-        assert_frame_equal(df.sort_index(axis=1), expected_df.sort_index(axis=1))
+        expected_df = pd.DataFrame({"id": ["id=id,timeshift=1", "id=id,timeshift=2", "id=id,timeshift=3"],
+                                    "kind": ["test"] * 3,
+                                    "value": [0, 1, 2],
+                                    "time": [0, 1, 2]})
+        assert_frame_equal(df.sort_index(axis=1).reset_index(drop=True), expected_df.sort_index(axis=1))
 
     def test_make_forecasting_frame_pdSeries(self):
 
@@ -851,13 +857,13 @@ class MakeForecastingFrameTestCase(TestCase):
 
         expected_y = pd.Series(data=[1, 2, 3], index=pd.DatetimeIndex(["2011-01-01 01:00:00", "2011-01-01 02:00:00",
                                                                        "2011-01-01 03:00:00"]), name="value")
-        expected_df = pd.DataFrame({"id": pd.DatetimeIndex(["2011-01-01 01:00:00", "2011-01-01 02:00:00",
-                                                            "2011-01-01 03:00:00"]),
-                                    "kind": ["test"] * 3, "value": [0., 1., 2.],
+        expected_df = pd.DataFrame({"id": ["id=id,timeshift=2011-01-01 01:00:00", "id=id,timeshift=2011-01-01 02:00:00",
+                                           "id=id,timeshift=2011-01-01 03:00:00"],
+                                    "kind": ["test"] * 3, "value": [0, 1, 2],
                                     "time": pd.DatetimeIndex(["2011-01-01 00:00:00", "2011-01-01 01:00:00",
                                                               "2011-01-01 02:00:00"])
                                     })
-        assert_frame_equal(df.sort_index(axis=1), expected_df.sort_index(axis=1))
+        assert_frame_equal(df.sort_index(axis=1).reset_index(drop=True), expected_df.sort_index(axis=1))
         assert_series_equal(y, expected_y)
 
 

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -335,6 +335,25 @@ class RollingTestCase(TestCase):
         self.assertListEqual(list(df["a"].values), correct_values_a)
         self.assertListEqual(list(df["b"].values), correct_values_b)
 
+        df = dataframe_functions.roll_time_series(df_full, column_id="id", column_sort="time",
+                                                  column_kind=None, rolling_direction=1,
+                                                  max_timeshift=2, min_timeshift=2)
+
+        correct_indices = [
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=2',
+            'id=1,timeshift=3',
+            'id=1,timeshift=3',
+            'id=1,timeshift=3',
+        ]
+        correct_values_a = [1.0, 2.0, 3.0, 2.0, 3.0, 4.0]
+        correct_values_b = [5.0, 6.0, 7.0, 6.0, 7.0, 8.0]
+
+        self.assertListEqual(list(df["id"]), correct_indices)
+        self.assertListEqual(list(df["a"].values), correct_values_a)
+        self.assertListEqual(list(df["b"].values), correct_values_b)
+
     def test_negative_rolling(self):
         first_class = pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8], "time": range(4)})
         second_class = pd.DataFrame({"a": [10, 11], "b": [12, 13], "time": range(20, 22)})
@@ -455,6 +474,28 @@ class RollingTestCase(TestCase):
         ]
         correct_values_a = [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 3.0, 4.0, 4.0, 10.0, 11.0, 11.0]
         correct_values_b = [5.0, 6.0, 7.0, 8.0, 6.0, 7.0, 8.0, 7.0, 8.0, 8.0, 12.0, 13.0, 13.0]
+
+        self.assertListEqual(list(df["id"].values), correct_indices)
+        self.assertListEqual(list(df["a"].values), correct_values_a)
+        self.assertListEqual(list(df["b"].values), correct_values_b)
+
+
+        df = dataframe_functions.roll_time_series(df_full, column_id="id", column_sort="time",
+                                                  column_kind=None, rolling_direction=-1,
+                                                  min_timeshift=2,
+                                                  max_timeshift=3)
+
+        correct_indices = [
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=0',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1',
+            'id=1,timeshift=1'
+        ]
+        correct_values_a = [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0]
+        correct_values_b = [5.0, 6.0, 7.0, 8.0, 6.0, 7.0, 8.0]
 
         self.assertListEqual(list(df["id"].values), correct_indices)
         self.assertListEqual(list(df["a"].values), correct_values_a)

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -353,7 +353,21 @@ class RollingTestCase(TestCase):
         5  11  13    21   2
         """
 
-        correct_indices = ([0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 20, 20, 21])
+        correct_indices = [
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=2',
+            'id=1,shift=2',
+            'id=1,shift=3',
+            'id=2,shift=0',
+            'id=2,shift=0',
+            'id=2,shift=1'
+        ]
         correct_values_a = [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 3.0, 4.0, 4.0, 10.0, 11.0, 11.0]
         correct_values_b = [5.0, 6.0, 7.0, 8.0, 6.0, 7.0, 8.0, 7.0, 8.0, 8.0, 12.0, 13.0, 13.0]
 
@@ -376,7 +390,18 @@ class RollingTestCase(TestCase):
                                                   column_kind=None, rolling_direction=-1,
                                                   max_timeshift=1)
 
-        correct_indices = ([0, 0, 1, 1, 2, 2, 3, 20, 20, 21])
+        correct_indices = [
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=2',
+            'id=1,shift=2',
+            'id=1,shift=3',
+            'id=2,shift=0',
+            'id=2,shift=0',
+            'id=2,shift=1'
+        ]
         correct_values_a = [1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 10.0, 11.0, 11.0]
         correct_values_b = [5.0, 6.0, 6.0, 7.0, 7.0, 8.0, 8.0, 12.0, 13.0, 13.0]
 
@@ -388,7 +413,20 @@ class RollingTestCase(TestCase):
                                                   column_kind=None, rolling_direction=-1,
                                                   max_timeshift=2)
 
-        correct_indices = ([0, 0, 0, 1, 1, 1, 2, 2, 3, 20, 20, 21])
+        correct_indices = [
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=2',
+            'id=1,shift=2',
+            'id=1,shift=3',
+            'id=2,shift=0',
+            'id=2,shift=0',
+            'id=2,shift=1'
+        ]
         correct_values_a = [1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 3.0, 4.0, 4.0, 10.0, 11.0, 11.0]
         correct_values_b = [5.0, 6.0, 7.0, 6.0, 7.0, 8.0, 7.0, 8.0, 8.0, 12.0, 13.0, 13.0]
 
@@ -400,7 +438,21 @@ class RollingTestCase(TestCase):
                                                   column_kind=None, rolling_direction=-1,
                                                   max_timeshift=4)
 
-        correct_indices = ([0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 20, 20, 21])
+        correct_indices = [
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=2',
+            'id=1,shift=2',
+            'id=1,shift=3',
+            'id=2,shift=0',
+            'id=2,shift=0',
+            'id=2,shift=1'
+        ]
         correct_values_a = [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 3.0, 4.0, 4.0, 10.0, 11.0, 11.0]
         correct_values_b = [5.0, 6.0, 7.0, 8.0, 6.0, 7.0, 8.0, 7.0, 8.0, 8.0, 12.0, 13.0, 13.0]
 
@@ -440,10 +492,16 @@ class RollingTestCase(TestCase):
         df = dataframe_functions.roll_time_series(df_stacked, column_id="id", column_sort="time",
                                                   column_kind="kind", rolling_direction=-1)
 
-        correct_indices = ([0] * 2 * 4 + [1] * 2 * 3 + [2] * 2 * 2 + [3] * 2 * 1 + [20] * 4 + [21] * 2)
+        correct_indices = (
+            ['id=1,shift=0'] * 2 * 4 +
+            ['id=1,shift=1'] * 2 * 3 +
+            ['id=1,shift=2'] * 2 * 2 +
+            ['id=1,shift=3'] * 2 * 1 +
+            ['id=2,shift=0'] * 2 * 2 +
+            ['id=2,shift=1'] * 2 * 1
+        )
         self.assertListEqual(list(df["id"].values), correct_indices)
 
-        print(df["_value"].values)
         self.assertListEqual(list(df["kind"].values), ["a", "b"] * 13)
         self.assertListEqual(list(df["_value"].values),
                              [1., 5., 2., 6., 3., 7., 4., 8., 2., 6., 3., 7., 4., 8., 3., 7., 4., 8., 4., 8., 10., 12.,
@@ -457,40 +515,41 @@ class RollingTestCase(TestCase):
         df = dataframe_functions.roll_time_series(df_dict, column_id="id", column_sort=None, column_kind=None,
                                                   rolling_direction=-1)
         """ df is
-        {a: _value  sort id
-         7      1.0   0.0  0
-         3      2.0   1.0  0
-         1      3.0   2.0  0
-         0      4.0   3.0  0
-         8      2.0   1.0  1
-         4      3.0   2.0  1
-         2      4.0   3.0  1
-         9      3.0   2.0  2
-         5      4.0   3.0  2
-         10     4.0   3.0  3
-         11    10.0   4.0  4
-         6     11.0   5.0  4
-         12    11.0   5.0  5,
+        {a: _value  id
+              1.0   1
+              2.0   1
+              3.0   1
+              4.0   1
+             10.0   2
+             11.0   2,
 
-         b: _value  sort id
-         7      5.0   0.0  0
-         3      6.0   1.0  0
-         1      7.0   2.0  0
-         0      8.0   3.0  0
-         8      6.0   1.0  1
-         4      7.0   2.0  1
-         2      8.0   3.0  1
-         9      7.0   2.0  2
-         5      8.0   3.0  2
-         10     8.0   3.0  3
-         11    12.0   4.0  4
-         6     13.0   5.0  4
-         12    13.0   5.0  5}
+         b: _value  id
+               5.0   1
+               6.0   1
+               7.0   1
+               8.0   1
+              12.0   2
+              13.0   2
+         }
         """
 
-        correct_indices = [0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 4, 4, 5]
-
+        correct_indices = [
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=2',
+            'id=1,shift=2',
+            'id=1,shift=3',
+            'id=2,shift=0',
+            'id=2,shift=0',
+            'id=2,shift=1'
+        ]
         self.assertListEqual(list(df["a"]["id"].values), correct_indices)
+
         self.assertListEqual(list(df["b"]["id"].values), correct_indices)
 
         self.assertListEqual(list(df["a"]["_value"].values),
@@ -506,32 +565,36 @@ class RollingTestCase(TestCase):
         df = dataframe_functions.roll_time_series(df_dict, column_id="id", column_sort=None, column_kind=None,
                                                   rolling_direction=-1, max_timeshift=1)
         """ df is
-        {a: _value  sort id
-         7      1.0   0.0  0
-         3      2.0   1.0  0
-         8      2.0   1.0  1
-         4      3.0   2.0  1
-         9      3.0   2.0  2
-         5      4.0   3.0  2
-         10     4.0   3.0  3
-         11    10.0   4.0  4
-         6     11.0   5.0  4
-         12    11.0   5.0  5,
+        {a: _value  id
+              1.0   1
+              2.0   1
+              3.0   1
+              4.0   1
+             10.0   2
+             11.0   2,
 
-         b: _value  sort id
-         7      5.0   0.0  0
-         3      6.0   1.0  0
-         8      6.0   1.0  1
-         4      7.0   2.0  1
-         9      7.0   2.0  2
-         5      8.0   3.0  2
-         10     8.0   3.0  3
-         11    12.0   4.0  4
-         6     13.0   5.0  4
-         12    13.0   5.0  5}
+         b: _value  id
+               5.0   1
+               6.0   1
+               7.0   1
+               8.0   1
+              12.0   2
+              13.0   2
+         }
         """
 
-        correct_indices = [0, 0, 1, 1, 2, 2, 3, 4, 4, 5]
+        correct_indices = [
+            'id=1,shift=0',
+            'id=1,shift=0',
+            'id=1,shift=1',
+            'id=1,shift=1',
+            'id=1,shift=2',
+            'id=1,shift=2',
+            'id=1,shift=3',
+            'id=2,shift=0',
+            'id=2,shift=0',
+            'id=2,shift=1'
+        ]
 
         self.assertListEqual(list(df["a"]["id"].values), correct_indices)
         self.assertListEqual(list(df["b"]["id"].values), correct_indices)
@@ -542,7 +605,7 @@ class RollingTestCase(TestCase):
     def test_warning_on_non_uniform_time_steps(self):
         with warnings.catch_warnings(record=True) as w:
             first_class = pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8], "time": [1, 2, 4, 5]})
-            second_class = pd.DataFrame({"a": [10, 11], "b": [12, 13], "time": range(20, 22)})
+            second_class = pd.DataFrame({"a": [10, 11], "b": [12, 13], "time": list(range(20, 22))})
 
             first_class["id"] = 1
             second_class["id"] = 2

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -557,8 +557,8 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
     # Now we know that this is a pandas data frame
     df = df_or_dict
 
-    if len(df) == 0:
-        raise ValueError("Your time series container has zero rows!. Can not perform rolling.")
+    if len(df) <= 1:
+        raise ValueError("Your time series container has zero or one rows!. Can not perform rolling.")
 
     if column_id is not None:
         if column_id not in df:

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -570,11 +570,11 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
     if distributor is None:
         if n_jobs == 0:
             distributor = MapDistributor(disable_progressbar=disable_progressbar,
-                                         progressbar_title="Feature Extraction")
+                                         progressbar_title="Rolling")
         else:
             distributor = MultiprocessingDistributor(n_workers=n_jobs,
                                                      disable_progressbar=disable_progressbar,
-                                                     progressbar_title="Feature Extraction",
+                                                     progressbar_title="Rolling",
                                                      show_warnings=show_warnings)
 
     if not isinstance(distributor, DistributorBaseClass):

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -383,7 +383,8 @@ def _roll_out_time_series(timeshift, grouped_data, rolling_direction, max_timesh
     This means it has shifted a virtual window if size `max_timeshift` (or infinite)
     `timeshift` times in the positive direction (for positive `rolling_direction`) or in negative direction
     (for negative `rolling_direction`).
-    It starts counting from the first data point for each id (and kind) (or the last one for negative `rolling_direction`).
+    It starts counting from the first data point for each id (and kind) (or the last one for negative
+    `rolling_direction`).
     The rolling happens for each `id` and `kind` separately.
     Extracted data smaller than `min_timeshift` + 1 are removed.
 
@@ -455,9 +456,10 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
     This method creates sub windows of the time series. It rolls the (sorted) data frames for each kind and each id
     separately in the "time" domain (which is represented by the sort order of the sort column given by `column_sort`).
 
-    For each rolling step, a new id is created by the scheme "id={id}, timeshift={shift}", here id is the former id of the
-    column and shift is the amount of "time" shifts.
-    You can think of it as having a window of fixed length (the max_timeshift) moving one step at a time over your time series.
+    For each rolling step, a new id is created by the scheme "id={id}, timeshift={shift}", here id is the former id of
+    the column and shift is the amount of "time" shifts.
+    You can think of it as having a window of fixed length (the max_timeshift) moving one step at a time over
+    your time series.
     Each cut-out seen by the window is a new time series with a new identifier.
 
     A few remarks:
@@ -496,10 +498,12 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
     :param rolling_direction: The sign decides, if to shift our cut-out window backwards or forwards in "time".
     :type rolling_direction: int
 
-    :param max_timeshift: If not None, the cut-out window is at maximum `max_timeshift` large. If none, it grows infinitely.
+    :param max_timeshift: If not None, the cut-out window is at maximum `max_timeshift` large. If none, it grows
+         infinitely.
     :type max_timeshift: int
 
-    :param min_timeshift: Throw away all extracted forecast windows smaller or equal than this. Must be larger than or equal 0.
+    :param min_timeshift: Throw away all extracted forecast windows smaller or equal than this. Must be larger
+         than or equal 0.
     :type min_timeshift: int
 
     :param n_jobs: The number of processes to use for parallelization. If zero, no parallelization is used.

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -557,6 +557,9 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
     # Now we know that this is a pandas data frame
     df = df_or_dict
 
+    if len(df) == 0:
+        raise ValueError("Your time series container has zero rows!. Can not perform rolling.")
+
     if column_id is not None:
         if column_id not in df:
             raise AttributeError("The given column for the id is not present in the data.")
@@ -594,9 +597,6 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
     grouped_data = df.groupby(grouper)
     prediction_steps = grouped_data.count().max().max()
 
-    if np.isnan(prediction_steps):
-        raise ValueError("Somehow the maximum length of your time series is NaN (Does your time series container have "
-                         "zero rows?). Can not perform rolling.")
     max_timeshift = max_timeshift or prediction_steps
 
     # Todo: not default for columns_sort to be None

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -375,7 +375,8 @@ def _normalize_input_to_internal_representation(timeseries_container, column_id,
     return timeseries_container, column_id, column_kind, column_value
 
 
-def _roll_out_time_series(time_shift, grouped_data, rolling_direction, max_timeshift, min_timeshift, column_sort, column_id):
+def _roll_out_time_series(time_shift, grouped_data, rolling_direction, max_timeshift, min_timeshift,
+                          column_sort, column_id):
     """
     Internal helper function for roll_time_series.
     This function has the task to extract the rolled forecast data frame of the number `time_shift`.
@@ -545,7 +546,7 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
             # Test if all differences are the same
             if differences and min(differences) != max(differences):
                 warnings.warn("Your time stamps are not uniformly sampled, which makes rolling "
-                            "nonsensical in some domains.")
+                              "nonsensical in some domains.")
 
     # Roll the data frames if requested
     rolling_direction = np.sign(rolling_direction)

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -482,7 +482,7 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
 
     :param column_id: it must be present in the pandas DataFrame or in all DataFrames in the dictionary.
         It is not allowed to have NaN values in this column.
-    :type column_id: basestring or None
+    :type column_id: basestring
 
     :param column_sort: if not None, sort the rows by this column. It is not allowed to
         have NaN values in this column. If not given, will be filled by an increasing number,

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -375,13 +375,13 @@ def _normalize_input_to_internal_representation(timeseries_container, column_id,
     return timeseries_container, column_id, column_kind, column_value
 
 
-def _roll_out_time_series(time_shift, grouped_data, rolling_direction, max_timeshift, min_timeshift,
+def _roll_out_time_series(timeshift, grouped_data, rolling_direction, max_timeshift, min_timeshift,
                           column_sort, column_id):
     """
     Internal helper function for roll_time_series.
-    This function has the task to extract the rolled forecast data frame of the number `time_shift`.
+    This function has the task to extract the rolled forecast data frame of the number `timeshift`.
     This means it has shifted a virtual window if size `max_timeshift` (or infinite)
-    `time_shift` times in the positive direction (for positive `rolling_direction`) or in negative direction
+    `timeshift` times in the positive direction (for positive `rolling_direction`) or in negative direction
     (for negative `rolling_direction`).
     It starts counting from the first data point for each id (and kind) (or the last one for negative `rolling_direction`).
     The rolling happens for each `id` and `kind` separately.
@@ -389,23 +389,23 @@ def _roll_out_time_series(time_shift, grouped_data, rolling_direction, max_times
 
     Implementation note:
     Even though negative rolling direction means, we let the window shift in negative direction over the data,
-    the counting of `time_shift` still happens from the first row onwards. Example:
+    the counting of `timeshift` still happens from the first row onwards. Example:
 
         1   2   3   4
 
     If we do positive rolling, we extract the sub time series
 
-      [ 1 ]               input parameter: time_shift=1, new id: id=X,timeshift=1
-      [ 1   2 ]           input parameter: time_shift=2, new id: id=X,timeshift=2
-      [ 1   2   3 ]       input parameter: time_shift=3, new id: id=X,timeshift=3
-      [ 1   2   3   4 ]   input parameter: time_shift=4, new id: id=X,timeshift=4
+      [ 1 ]               input parameter: timeshift=1, new id: id=X,timeshift=1
+      [ 1   2 ]           input parameter: timeshift=2, new id: id=X,timeshift=2
+      [ 1   2   3 ]       input parameter: timeshift=3, new id: id=X,timeshift=3
+      [ 1   2   3   4 ]   input parameter: timeshift=4, new id: id=X,timeshift=4
 
     If we do negative rolling:
 
-      [ 1   2   3   4 ]   input parameter: time_shift=1, new id: id=X,timeshift=1
-          [ 2   3   4 ]   input parameter: time_shift=2, new id: id=X,timeshift=2
-              [ 3   4 ]   input parameter: time_shift=3, new id: id=X,timeshift=3
-                  [ 4 ]   input parameter: time_shift=4, new id: id=X,timeshift=4
+      [ 1   2   3   4 ]   input parameter: timeshift=1, new id: id=X,timeshift=1
+          [ 2   3   4 ]   input parameter: timeshift=2, new id: id=X,timeshift=2
+              [ 3   4 ]   input parameter: timeshift=3, new id: id=X,timeshift=3
+                  [ 4 ]   input parameter: timeshift=4, new id: id=X,timeshift=4
 
     If you now reverse the order of the negative examples, it looks like shifting the
     window from the back (but it is implemented to start counting from the beginning).
@@ -413,14 +413,14 @@ def _roll_out_time_series(time_shift, grouped_data, rolling_direction, max_times
     """
     def _f(x):
         if rolling_direction > 0:
-            # For positive rolling, the right side of the window moves with `time_shift`
-            shift_until = time_shift
+            # For positive rolling, the right side of the window moves with `timeshift`
+            shift_until = timeshift
             shift_from = max(shift_until - max_timeshift - 1, 0)
 
             df_temp = x.iloc[shift_from:shift_until] if shift_until <= len(x) else None
         else:
-            # For negative rolling, the left side of the window moves with `time_shift`
-            shift_from = max(time_shift - 1, 0)
+            # For negative rolling, the left side of the window moves with `timeshift`
+            shift_from = max(timeshift - 1, 0)
             shift_until = shift_from + max_timeshift + 1
 
             df_temp = x.iloc[shift_from:shift_until]
@@ -436,7 +436,7 @@ def _roll_out_time_series(time_shift, grouped_data, rolling_direction, max_times
         elif column_sort and rolling_direction < 0:
             shift_string = "timeshift=" + str(df_temp[column_sort].iloc[0])
         else:
-            shift_string = "timeshift=" + str(time_shift - 1)
+            shift_string = "timeshift=" + str(timeshift - 1)
         # and now create new ones ids out of the old ones
         df_temp["id"] = df_temp.apply(lambda row: "id=" + str(row[column_id]) + "," + str(shift_string), axis=1)
 

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -404,13 +404,13 @@ def _roll_out_time_series(time_shift, grouped_data, rolling_direction, max_times
 
         # and set the shift correctly
         if column_sort and rolling_direction > 0:
-            shift_string = f"timeshift={df_temp[column_sort].iloc[-1]}"
+            shift_string = "timeshift=" + str(df_temp[column_sort].iloc[-1])
         elif column_sort and rolling_direction < 0:
-            shift_string = f"timeshift={df_temp[column_sort].iloc[0]}"
+            shift_string = "timeshift=" + str(df_temp[column_sort].iloc[0])
         else:
-            shift_string = f"timeshift={time_shift - 1}"
+            shift_string = "timeshift=" + str(time_shift - 1)
         # and now create new ones ids out of the old ones
-        df_temp["id"] = df_temp.apply(lambda row: f"id={row[column_id]},{shift_string}", axis=1)
+        df_temp["id"] = df_temp.apply(lambda row: "id=" + str(row[column_id]) + "," + str(shift_string), axis=1)
 
         return df_temp
 


### PR DESCRIPTION
`tsfresh` is used for time series forecasting a lot . However, our rolling function is a common source for problems.
This PR tries to solve many of them:
1. it speeds up the process by making the rolling multiprocessing ready. Same as the feature extraction, it will also work with a distributor (if passed) and works with multiprocessing out of the box
2. it corrects/improves the documentation, hopefully it is clearer now
3. it simplifies the code for the rolling logic, so people that want to have a look into the code can read it more clearly what is going on
4. it brings back the new identifiers, which got lost unfortunately at some point. Instead of just writing `<timeshift>` as the new identifier, we now (again) write `id=<id>,timeshift=<timeshift>` as the former has problems if there is more than one id.

This fixes (maybe) #659, #646, #638 (well, at least partly), #673.

@MaxBenChrist what do you think. I need your input here.