### PR TITLE
Optimize RelevantFeatureAugmenter to avoid re-extraction

### DIFF
--- a/tsfresh/transformers/relevant_feature_augmenter.py
+++ b/tsfresh/transformers/relevant_feature_augmenter.py
@@ -254,52 +254,7 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         :return: the fitted estimator with the information, which features are relevant.
         :rtype: RelevantFeatureAugmenter
         """
-        if self.timeseries_container is None:
-            raise RuntimeError("You have to provide a time series using the set_timeseries_container function before.")
-
-        self.feature_extractor = FeatureAugmenter(
-            default_fc_parameters=self.default_fc_parameters,
-            kind_to_fc_parameters=self.kind_to_fc_parameters,
-            column_id=self.column_id,
-            column_sort=self.column_sort,
-            column_kind=self.column_kind,
-            column_value=self.column_value,
-            timeseries_container=self.timeseries_container,
-            chunksize=self.chunksize,
-            n_jobs=self.n_jobs,
-            show_warnings=self.show_warnings,
-            disable_progressbar=self.disable_progressbar,
-            profile=self.profile,
-            profiling_filename=self.profiling_filename,
-            profiling_sorting=self.profiling_sorting
-        )
-
-        self.feature_selector = FeatureSelector(
-            test_for_binary_target_binary_feature=self.test_for_binary_target_binary_feature,
-            test_for_binary_target_real_feature=self.test_for_binary_target_real_feature,
-            test_for_real_target_binary_feature=self.test_for_real_target_binary_feature,
-            test_for_real_target_real_feature=self.test_for_real_target_real_feature,
-            fdr_level=self.fdr_level,
-            hypotheses_independent=self.hypotheses_independent,
-            n_jobs=self.n_jobs,
-            chunksize=self.chunksize,
-            ml_task=self.ml_task
-        )
-
-        if self.filter_only_tsfresh_features:
-            # Do not merge the time series features to the old features
-            X_tmp = pd.DataFrame(index=X.index)
-        else:
-            X_tmp = X
-
-        X_augmented = self.feature_extractor.transform(X_tmp)
-
-        self.col_to_max, self.col_to_min, self.col_to_median = get_range_values_per_column(X_augmented)
-        X_augmented = impute_dataframe_range(X_augmented, col_to_max=self.col_to_max, col_to_median=self.col_to_median,
-                                             col_to_min=self.col_to_min)
-
-        self.feature_selector.fit(X_augmented, y)
-
+        self._fit_and_augment(X, y)
         return self
 
     def transform(self, X):
@@ -362,7 +317,8 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
 
     def fit_transform(self, X, y):
         """
-        Equivalent to fit() followed by transform(); however, this is faster than performing those steps separately.
+        Equivalent to :func:`~fit` followed by :func:`~transform`; however, this is faster than performing those steps
+        separately, because it avoids re-extracting relevant features for training data.
 
         :param X: The data frame without the time series features. The index rows should be present in the timeseries
            and in the target vector.
@@ -374,6 +330,28 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         :return: a data sample with the same information as X, but with added relevant time series features and
             deleted irrelevant information (only if filter_only_tsfresh_features is False).
         :rtype: pandas.DataFrame
+        """
+        X_augmented = self._fit_and_augment(X, y)
+
+        if self.filter_only_tsfresh_features:
+            return X_augmented.copy().loc[:, self.feature_selector.relevant_features + X.columns.tolist()]
+        else:
+            return X_augmented.copy().loc[:, self.feature_selector.relevant_features]
+
+    def _fit_and_augment(self, X, y):
+        """
+        Helper for the :func:`~fit` and :func:`~fit_transform` functions, which does most of the work described in
+        :func:`~fit`.
+
+        :param X: The data frame without the time series features. The index rows should be present in the timeseries
+           and in the target vector.
+        :type X: pandas.DataFrame or numpy.array
+
+        :param y: The target vector to define, which features are relevant.
+        :type y: pandas.Series or numpy.array
+
+        :return: the fitted estimator with the information, which features are relevant.
+        :rtype: RelevantFeatureAugmenter
         """
         if self.timeseries_container is None:
             raise RuntimeError("You have to provide a time series using the set_timeseries_container function before.")
@@ -421,7 +399,4 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
 
         self.feature_selector.fit(X_augmented, y)
 
-        if self.filter_only_tsfresh_features:
-            return X_augmented.copy().loc[:, self.feature_selector.relevant_features + X.columns.tolist()]
-        else:
-            return X_augmented.copy().loc[:, self.feature_selector.relevant_features]
+        return X_augmented

--- a/tsfresh/transformers/relevant_feature_augmenter.py
+++ b/tsfresh/transformers/relevant_feature_augmenter.py
@@ -359,3 +359,69 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
             return X_augmented.copy().loc[:, self.feature_selector.relevant_features + X.columns.tolist()]
         else:
             return X_augmented.copy().loc[:, self.feature_selector.relevant_features]
+
+    def fit_transform(self, X, y):
+        """
+        Equivalent to fit() followed by transform(); however, this is faster than performing those steps separately.
+
+        :param X: The data frame without the time series features. The index rows should be present in the timeseries
+           and in the target vector.
+        :type X: pandas.DataFrame or numpy.array
+
+        :param y: The target vector to define, which features are relevant.
+        :type y: pandas.Series or numpy.array
+
+        :return: a data sample with the same information as X, but with added relevant time series features and
+            deleted irrelevant information (only if filter_only_tsfresh_features is False).
+        :rtype: pandas.DataFrame
+        """
+        if self.timeseries_container is None:
+            raise RuntimeError("You have to provide a time series using the set_timeseries_container function before.")
+
+        self.feature_extractor = FeatureAugmenter(
+            default_fc_parameters=self.default_fc_parameters,
+            kind_to_fc_parameters=self.kind_to_fc_parameters,
+            column_id=self.column_id,
+            column_sort=self.column_sort,
+            column_kind=self.column_kind,
+            column_value=self.column_value,
+            timeseries_container=self.timeseries_container,
+            chunksize=self.chunksize,
+            n_jobs=self.n_jobs,
+            show_warnings=self.show_warnings,
+            disable_progressbar=self.disable_progressbar,
+            profile=self.profile,
+            profiling_filename=self.profiling_filename,
+            profiling_sorting=self.profiling_sorting
+        )
+
+        self.feature_selector = FeatureSelector(
+            test_for_binary_target_binary_feature=self.test_for_binary_target_binary_feature,
+            test_for_binary_target_real_feature=self.test_for_binary_target_real_feature,
+            test_for_real_target_binary_feature=self.test_for_real_target_binary_feature,
+            test_for_real_target_real_feature=self.test_for_real_target_real_feature,
+            fdr_level=self.fdr_level,
+            hypotheses_independent=self.hypotheses_independent,
+            n_jobs=self.n_jobs,
+            chunksize=self.chunksize,
+            ml_task=self.ml_task
+        )
+
+        if self.filter_only_tsfresh_features:
+            # Do not merge the time series features to the old features
+            X_tmp = pd.DataFrame(index=X.index)
+        else:
+            X_tmp = X
+
+        X_augmented = self.feature_extractor.transform(X_tmp)
+
+        self.col_to_max, self.col_to_min, self.col_to_median = get_range_values_per_column(X_augmented)
+        X_augmented = impute_dataframe_range(X_augmented, col_to_max=self.col_to_max, col_to_median=self.col_to_median,
+                                             col_to_min=self.col_to_min)
+
+        self.feature_selector.fit(X_augmented, y)
+
+        if self.filter_only_tsfresh_features:
+            return X_augmented.copy().loc[:, self.feature_selector.relevant_features + X.columns.tolist()]
+        else:
+            return X_augmented.copy().loc[:, self.feature_selector.relevant_features]


### PR DESCRIPTION
I am working on some datasets where the feature extraction step is very time consuming, sometimes totaling multiple days when running a suite of experiments. I'm using `RelevantFeatureAugmenter` in a scikit-learn `Pipeline` object, and noticed that the training features are extracted twice, because `fit()` extracts them once and `transform()` re-extracts a subset of them (the relevant ones). I see why this is needed, since `fit()` and `transform()` need to be independent for the sake of re-applying the transformer to new data.

However, in a scikit-learn pipeline, `fit_transform()` is called during training since the two steps are sequential. For these situations, I added a `fit_transform()` function which avoids re-extracting the relevant features.

I created a small simulated dataset to test the effect:
```python
# Randomly generate timeseries data for performance testing.
import pandas as pd
import numpy as np
import scipy as sp
from sklearn.pipeline import Pipeline
from sklearn.ensemble import RandomForestClassifier
from sklearn.model_selection import cross_val_score
from tsfresh.transformers import RelevantFeatureAugmenter


def gen_classification(n_instances, n_cols, seq_len, noise_prop, n_classes=2, random_state=1):
    np.random.seed(random_state)
    X = pd.DataFrame({'feature' + str(f): [0] * n_instances * seq_len for f in range(n_cols)})
    y = pd.Series([np.random.choice(n_classes) for _ in range(n_instances)])
    X['instance_id'] = [i for i in range(n_instances) for _ in range(seq_len)]
    X['order'] = range(len(X))
    axis = np.linspace(0, 1, num=seq_len)
    for col_i in range(n_cols):
        form = np.random.choice(['square', 'sin', 'sawtooth', 'uniform', 'random'])
        hz = np.random.random() * seq_len
        for i in range(n_instances):
            if form == 'square':
                ts = (sp.signal.square(axis * 2 * np.pi * hz) + 1) / 2
            elif form == 'sin':
                ts = np.sin(axis * 2 * np.pi * hz)
            elif form == 'sawtooth':
                ts = (sp.signal.sawtooth(axis * 2 * np.pi * hz) + 1) / 2
            elif form == 'uniform':
                ts = axis * 0
            elif form == 'random':
                ts = np.random.random(seq_len)
            ts += y[i] * (1 - noise_prop)  # Distinguish classes
            ts += (np.random.random(seq_len) - .5) * noise_prop  # Add noise
            X.loc[i * seq_len:i * seq_len + seq_len - 1, 'feature' + str(col_i)] = ts
    return X, y


if __name__ == '__main__':
    ts, y = gen_classification(500, 10, 5, .9)
    augmenter = RelevantFeatureAugmenter(column_id='instance_id', column_sort='order',
                                         timeseries_container=ts, hypotheses_independent=True)
    pipeline = Pipeline([('augmenter', augmenter),
                         ('classifier', RandomForestClassifier(random_state=1))])
    X = pd.DataFrame(index=y.index)
    print('Cross-val accuracies:', cross_val_score(pipeline, X, y, cv=4))
```

Before this optimization, the above code took 5m36s to run on my computer. After, it took 4m24s. In detail, the output before this optimization:
```
$ time python perftest.py
Feature Extraction: 100%|████████████████████████████| 20/20 [00:46<00:00,  2.35s/it]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:17<00:00,  1.12it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:06<00:00,  3.30it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:46<00:00,  2.31s/it]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:14<00:00,  1.43it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:04<00:00,  4.30it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:46<00:00,  2.33s/it]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:13<00:00,  1.44it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:04<00:00,  4.31it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:47<00:00,  2.36s/it]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:17<00:00,  1.16it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:05<00:00,  3.53it/s]
Cross-val accuracies: [0.928 0.912 0.944 0.936]

real    5m36.578s
user    19m17.094s
sys     0m17.709s
```

It is apparent in the above output that, for each of the 4 cross-validation folds, the initial feature extraction takes longest, followed by a shorter re-extraction of only relevant features in training data, followed by an even shorter extraction of relevant features in testing data. This second step is the one that can be avoided. The new output after this optimization looks like this:

```
$ time python perftest.py
Feature Extraction: 100%|████████████████████████████| 20/20 [00:44<00:00,  2.20s/it]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:05<00:00,  3.43it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:46<00:00,  2.34s/it]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:04<00:00,  4.15it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:51<00:00,  2.59s/it]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:04<00:00,  4.01it/s]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:46<00:00,  2.33s/it]
Feature Extraction: 100%|████████████████████████████| 20/20 [00:05<00:00,  3.91it/s]
Cross-val accuracies: [0.928 0.912 0.944 0.936]

real    4m24.546s
user    15m7.825s
sys     0m15.585s
```

The re-extraction step is now gone. This saves me a ton of time in practice, especially for datasets with many relevant features.