### PR TITLE
Prevent wrong indices in the passed time series container

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 ==========
 - Added Features
     - Implemented the Lempel-Ziv-Complexity and the Fourier Entropy (#688)
+    - Prevent #524 by adding an assert for common identifiers (#690)
 
 Version 0.16.0
 ==============

--- a/tests/units/transformers/test_feature_augmenter.py
+++ b/tests/units/transformers/test_feature_augmenter.py
@@ -90,5 +90,5 @@ class FeatureAugmenterTestCase(DataTestCase):
         augmenter.set_timeseries_container(self.test_df)
 
         X_with_not_all_ids = pd.DataFrame([{"feature_1": 1}], index=[-999])
-        self.assertRaisesRegex(AttributeError, r"The ids of the time series container", augmenter.transform, X_with_not_all_ids)
-
+        self.assertRaisesRegex(AttributeError, r"The ids of the time series container",
+                               augmenter.transform, X_with_not_all_ids)

--- a/tests/units/transformers/test_feature_augmenter.py
+++ b/tests/units/transformers/test_feature_augmenter.py
@@ -79,3 +79,16 @@ class FeatureAugmenterTestCase(DataTestCase):
             print((index, row))
             self.assertFalse(np.isnan(row["a__length"]))
             self.assertFalse(np.isnan(row["b__length"]))
+
+    def test_no_ids_present(self):
+        augmenter = FeatureAugmenter(column_value="val", column_id="id", column_sort="sort",
+                                     column_kind="kind",
+                                     kind_to_fc_parameters=self.kind_to_fc_parameters,
+                                     n_jobs=0,
+                                     disable_progressbar=True)
+
+        augmenter.set_timeseries_container(self.test_df)
+
+        X_with_not_all_ids = pd.DataFrame([{"feature_1": 1}], index=[-999])
+        self.assertRaisesRegex(AttributeError, r"The ids of the time series container", augmenter.transform, X_with_not_all_ids)
+

--- a/tests/units/transformers/test_relevant_feature_augmenter.py
+++ b/tests/units/transformers/test_relevant_feature_augmenter.py
@@ -110,7 +110,6 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         assert calculate_relevance_table_mock.call_count == 1
         assert not calculate_relevance_table_mock.call_args[0][0].isnull().any().any()
 
-
     def test_no_ids_present(self):
         augmenter = RelevantFeatureAugmenter(kind_to_fc_parameters=self.kind_to_fc_parameters,
                                              filter_only_tsfresh_features=False,
@@ -121,7 +120,8 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
 
         augmenter.set_timeseries_container(df)
 
-        self.assertRaisesRegex(AttributeError, r"The ids of the time series container", augmenter.fit, X_with_wrong_ids, y)
+        self.assertRaisesRegex(AttributeError, r"The ids of the time series container",
+                               augmenter.fit, X_with_wrong_ids, y)
 
 
 def test_relevant_augmentor_cross_validated():

--- a/tests/units/transformers/test_relevant_feature_augmenter.py
+++ b/tests/units/transformers/test_relevant_feature_augmenter.py
@@ -111,6 +111,19 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         assert not calculate_relevance_table_mock.call_args[0][0].isnull().any().any()
 
 
+    def test_no_ids_present(self):
+        augmenter = RelevantFeatureAugmenter(kind_to_fc_parameters=self.kind_to_fc_parameters,
+                                             filter_only_tsfresh_features=False,
+                                             column_value="val", column_id="id", column_sort="sort", column_kind="kind")
+
+        df, y = self.create_test_data_sample_with_target()
+        X_with_wrong_ids = pd.DataFrame(index=[-999])
+
+        augmenter.set_timeseries_container(df)
+
+        self.assertRaisesRegex(AttributeError, r"The ids of the time series container", augmenter.fit, X_with_wrong_ids, y)
+
+
 def test_relevant_augmentor_cross_validated():
     """Validates that the RelevantFeatureAugmenter can cloned in pipelines, see issue 537
     """

--- a/tsfresh/transformers/feature_augmenter.py
+++ b/tsfresh/transformers/feature_augmenter.py
@@ -24,23 +24,26 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
     1. the time series container with the timeseries data. This container (for the format see :ref:`data-formats-label`)
        contains the data which is used for calculating the
        features. It must be groupable by ids which are used to identify which feature should be attached to which row
-       in the second dataframe:
+       in the second dataframe.
 
-    2. the input data, where the features will be added to.
+    2. the input data X, where the features will be added to. Its rows are identifies by the index and each index in
+       X must be present as an id in the time series container.
 
     Imagine the following situation: You want to classify 10 different financial shares and you have their development
     in the last year as a time series. You would then start by creating features from the metainformation of the
     shares, e.g. how long they were on the market etc. and filling up a table - the features of one stock in one row.
+    This is the input array X, which each row identified by e.g. the stock name as an index.
 
-    >>> df = pandas.DataFrame()
+    >>> df = pandas.DataFrame(index=["AAA", "BBB", ...])
     >>> # Fill in the information of the stocks
-    >>> df["started_since_days"] = 0 # add a feature
+    >>> df["started_since_days"] = ... # add a feature
 
-    You can then extract all the features from the time development of the shares, by using this estimator:
+    You can then extract all the features from the time development of the shares, by using this estimator.
+    The time series container must include a column of ids, which are the same as the index of X.
 
     >>> time_series = read_in_timeseries() # get the development of the shares
     >>> from tsfresh.transformers import FeatureAugmenter
-    >>> augmenter = FeatureAugmenter()
+    >>> augmenter = FeatureAugmenter(column_id="id")
     >>> augmenter.set_timeseries_container(time_series)
     >>> df_with_time_series_features = augmenter.transform(df)
 

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -200,9 +200,16 @@ def restrict_input_to_index(df_or_dict, column_id, index):
     :raise: ``TypeError`` if df_or_dict is not of type dict or pandas.DataFrame
     """
     if isinstance(df_or_dict, pd.DataFrame):
+        ids_in_df = set(df_or_dict[column_id])
+        ids_in_index = set(index)
+        present_ids = ids_in_index & ids_in_df
+        if not present_ids:
+            msg = "The ids of the time series container and the index of the input data X do not share any identifier!"
+            raise AttributeError(msg)
+
         df_or_dict_restricted = df_or_dict[df_or_dict[column_id].isin(index)]
     elif isinstance(df_or_dict, dict):
-        df_or_dict_restricted = {kind: df[df[column_id].isin(index)]
+        df_or_dict_restricted = {kind: restrict_input_to_index(df, column_id, index)
                                  for kind, df in df_or_dict.items()}
     else:
         raise TypeError("df_or_dict should be of type dict or pandas.DataFrame")


### PR DESCRIPTION
Following the discussion in #524 we have to make sure that the ids present in the time series container and the given index have at least something in common (otherwise it makes no sense).

@JacquesDonnelly that should have prevented at least your problem!