### PR TITLE
Make sure X and y are sorted equally in select_features

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Unreleased
     - Speed up the result pivoting (#705)
 - Bugfixes:
     - Fixed readthedocs (#695, #696)
+    - Fixed a bug in the selection, that caused all regression tasks with un-ordered index to be wrong (#715)
 
 Version 0.16.0
 ==============

--- a/tests/integrations/examples/test_driftbif_simulation.py
+++ b/tests/integrations/examples/test_driftbif_simulation.py
@@ -7,6 +7,7 @@ import unittest
 import pandas as pd
 
 from tsfresh.examples.driftbif_simulation import velocity, load_driftbif, sample_tau
+from tsfresh import extract_relevant_features
 
 
 class DriftBifSimlationTestCase(unittest.TestCase):
@@ -62,6 +63,16 @@ class DriftBifSimlationTestCase(unittest.TestCase):
         v = ds.simulate(Nt, v0=np.zeros(3))
         self.assertEqual(v.shape, (Nt, 3),
                          'The returned vector should reflect the dimension of the initial condition.')
+
+    def test_relevant_feature_extraction(self):
+        df, y = load_driftbif(100, 10, classification=False, seed=42)
+
+        df['id'] = df['id'].astype('str')
+        y.index = y.index.astype('str')
+
+        X = extract_relevant_features(df, y, column_id="id", column_sort="time", column_kind="dimension", column_value="value")
+
+        self.assertGreater(len(X.columns), 10)
 
 
 class SampleTauTestCase(unittest.TestCase):

--- a/tests/integrations/examples/test_driftbif_simulation.py
+++ b/tests/integrations/examples/test_driftbif_simulation.py
@@ -70,7 +70,9 @@ class DriftBifSimlationTestCase(unittest.TestCase):
         df['id'] = df['id'].astype('str')
         y.index = y.index.astype('str')
 
-        X = extract_relevant_features(df, y, column_id="id", column_sort="time", column_kind="dimension", column_value="value")
+        X = extract_relevant_features(df, y,
+                                      column_id="id", column_sort="time",
+                                      column_kind="dimension", column_value="value")
 
         self.assertGreater(len(X.columns), 10)
 

--- a/tests/units/feature_selection/test_relevance.py
+++ b/tests/units/feature_selection/test_relevance.py
@@ -83,8 +83,14 @@ class TestCalculateRelevanceTable:
 
         assert 0.5 == relevance_table.loc['feature_binary'].p_value
         assert 0.7 == relevance_table.loc['feature_real'].p_value
-        significance_test_feature_binary_mock.assert_called_once_with(X['feature_binary'], y=y_real)
-        significance_test_feature_real_mock.assert_called_once_with(X['feature_real'], y=y_real)
+
+        assert significance_test_feature_binary_mock.call_count == 1
+        pd.testing.assert_series_equal(significance_test_feature_binary_mock.call_args[0][0], X["feature_binary"])
+        pd.testing.assert_series_equal(significance_test_feature_binary_mock.call_args[1]["y"], y_real)
+
+        assert significance_test_feature_real_mock.call_count == 1
+        pd.testing.assert_series_equal(significance_test_feature_real_mock.call_args[0][0], X["feature_real"])
+        pd.testing.assert_series_equal(significance_test_feature_real_mock.call_args[1]["y"], y_real)
 
     @mock.patch('tsfresh.feature_selection.relevance.target_real_feature_real_test')
     @mock.patch('tsfresh.feature_selection.relevance.target_real_feature_binary_test')

--- a/tsfresh/feature_selection/relevance.py
+++ b/tsfresh/feature_selection/relevance.py
@@ -131,6 +131,13 @@ def calculate_relevance_table(X, y, ml_task='auto', n_jobs=defaults.N_PROCESSES,
              not relevant] for this feature)
     :rtype: pandas.DataFrame
     """
+
+    # Make sure X and y both have the exact same indices
+    y = y.sort_index()
+    X = X.sort_index()
+
+    assert list(y.index) == list(X.index), "The index of X and y need to be the same"
+
     if ml_task not in ['auto', 'classification', 'regression']:
         raise ValueError('ml_task must be one of: \'auto\', \'classification\', \'regression\'')
     elif ml_task == 'auto':

--- a/tsfresh/feature_selection/selection.py
+++ b/tsfresh/feature_selection/selection.py
@@ -140,11 +140,6 @@ def select_features(X, y, test_for_binary_target_binary_feature=defaults.TEST_FO
     if isinstance(y, np.ndarray):
         y = pd.Series(y, index=X.index)
 
-    y = y.sort_index()
-    X = X.sort_index()
-
-    assert list(y.index) == list(X.index), "The index of X and y need to be the same"
-
     relevance_table = calculate_relevance_table(
         X, y, ml_task=ml_task, n_jobs=n_jobs, show_warnings=show_warnings, chunksize=chunksize,
         test_for_binary_target_real_feature=test_for_binary_target_real_feature,

--- a/tsfresh/feature_selection/selection.py
+++ b/tsfresh/feature_selection/selection.py
@@ -140,6 +140,11 @@ def select_features(X, y, test_for_binary_target_binary_feature=defaults.TEST_FO
     if isinstance(y, np.ndarray):
         y = pd.Series(y, index=X.index)
 
+    y = y.sort_index()
+    X = X.sort_index()
+
+    assert list(y.index) == list(X.index), "The index of X and y need to be the same"
+
     relevance_table = calculate_relevance_table(
         X, y, ml_task=ml_task, n_jobs=n_jobs, show_warnings=show_warnings, chunksize=chunksize,
         test_for_binary_target_real_feature=test_for_binary_target_real_feature,

--- a/tsfresh/feature_selection/significance_tests.py
+++ b/tsfresh/feature_selection/significance_tests.py
@@ -203,6 +203,8 @@ def __check_if_pandas_series(x, y):
         raise TypeError("x should be a pandas Series")
     if not isinstance(y, pd.Series):
         raise TypeError("y should be a pandas Series")
+    if not list(y.index) == list(x.index):
+        raise ValueError("X and y need to have the same index!")
 
 
 def __check_for_binary_target(y):


### PR DESCRIPTION
This looks like a quite large bug to me. 

In principle, X and y could have the same index entries (what we check), but we never check if the order is the same! So passing in a `X` with index `[0, 1, 2]` and a `y` with index `[2, 1, 0]` will not raise any problems.

For classification tasks, this is not a problem, as all the significance tests except `target_real_feature_real_test` do not care about the order of the index, as `x` and `y` are re-ordered internally again in all the other tasks. But for `target_real_feature_real_test` the index is stripped before any re-order could happen - which leads to the bug described in #713.

This PR fixes this. I am a bit puzzled why this was never a problem before :-/ 
Therefore I added the exact test from the issue, to see any degradation again.
@MaxBenChrist as a general remark: we should add more tests on `select_features` :-)
