### PR TITLE
Add RollingWideTsFrameAdapter along with helper functions

### DIFF
--- a/tsfresh/feature_extraction/data.py
+++ b/tsfresh/feature_extraction/data.py
@@ -2,8 +2,6 @@ import itertools
 from collections import namedtuple
 from typing import Generator, Iterable, Sized
 
-from tsfresh.utilities.dataframe_functions import window
-
 import pandas as pd
 
 
@@ -295,6 +293,34 @@ class TsDictAdapter(TsData):
 
     def __len__(self):
         return sum(grouped_df.ngroups for grouped_df in self.grouped_dict.values())
+
+
+def window(seq, window_width):
+    """
+    Returns a sliding window (of width n) over data from the iterable
+    s -> (s0,s1,...s[n-1]), (s1,s2,...,sn), ...
+
+    Taken from: https://stackoverflow.com/questions/6822725/rolling-or-sliding-window-iterator
+    """
+
+    # it = s0, s1, ...,
+    it = iter(seq)
+
+    # islice just takes the first n terms
+    # Therefore it iterates through the first n terms of it
+    # result = (it0, it1, ... itn)
+    result = tuple(itertools.islice(it, window_width))
+
+    # yield the first result
+    if len(result) == window_width:
+        yield result
+        # it = s[n+1], s[n+2], ...
+        # result = (it0, it1, ... itn) = (s0, s1, ..., sn)
+
+    # Iteratively drop the first term of result and append the first elem of 'it' to results
+    for elem in it:
+        result = result[1:] + (elem,)
+        yield result
 
 class RollingWideTsFrameAdapter(SliceableTsData):
 

--- a/tsfresh/feature_extraction/data.py
+++ b/tsfresh/feature_extraction/data.py
@@ -322,12 +322,13 @@ def window(seq, window_width):
         result = result[1:] + (elem,)
         yield result
 
+
 class RollingWideTsFrameAdapter(SliceableTsData):
 
     def __init__(self, df, column_id, window_width, column_sort=None, value_columns=None):
         """
-        Rolling window adapter for Pandas DataFrames in wide format, where multiple columns contain different time series for
-        the same id.
+        Rolling window adapter for Pandas DataFrames in wide format, where multiple columns
+        contain different time series for the same id.
 
         :param df: the data frame
         :type df: pd.DataFrame
@@ -370,7 +371,9 @@ class RollingWideTsFrameAdapter(SliceableTsData):
             self.df_grouped = df.groupby([column_id])
             self.column_sort = column_id
 
-        assert df.groupby(column_id).count().min().min() >= window_width, 'window_width must be equal to or less than the length of the smallest time series'
+        assert (
+            df.groupby(column_id).count().min().min() >= window_width
+        ), "window_width must be equal to or less than the length of the smallest time series"
 
         self.window_width = window_width
         self.num_windows = df.groupby(column_id).count().min(axis=1) - window_width + 1

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -252,7 +252,7 @@ def _do_extraction(df, column_id, column_value, column_kind, column_sort,
     return_df = pivot_list(result, dtype=float)
 
     # copy the type of the index
-    return_df.index = return_df.index.astype(df[column_id].dtype)
+    return_df.index = return_df.index.astype(data.column_id_dtype)
 
     # Sort by index to be backward compatible
     return_df = return_df.sort_index()

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -674,31 +674,3 @@ def pivot_list(list_of_tuples, **kwargs):
     # column with index.
     # All index will be aligned.
     return pd.DataFrame(return_df_dict, **kwargs)
-
-
-def window(seq, window_width):
-    """
-    Returns a sliding window (of width n) over data from the iterable
-    s -> (s0,s1,...s[n-1]), (s1,s2,...,sn), ...
-
-    Taken from: https://stackoverflow.com/questions/6822725/rolling-or-sliding-window-iterator
-    """
-
-    # it = s0, s1, ...,
-    it = iter(seq)
-
-    # islice just takes the first n terms
-    # Therefore it iterates through the first n terms of it
-    # result = (it0, it1, ... itn)
-    result = tuple(itertools.islice(it, window_width))
-
-    # yield the first result
-    if len(result) == window_width:
-        yield result
-        # it = s[n+1], s[n+2], ...
-        # result = (it0, it1, ... itn) = (s0, s1, ..., sn)
-
-    # Iteratively drop the first term of result and append the first elem of 'it' to results
-    for elem in it:
-        result = result[1:] + (elem,)
-        yield result

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -11,6 +11,8 @@ from collections import defaultdict
 import numpy as np
 import pandas as pd
 
+import itertools
+
 from tsfresh import defaults
 from tsfresh.utilities.distribution import MapDistributor, MultiprocessingDistributor, DistributorBaseClass
 
@@ -672,3 +674,31 @@ def pivot_list(list_of_tuples, **kwargs):
     # column with index.
     # All index will be aligned.
     return pd.DataFrame(return_df_dict, **kwargs)
+
+
+def window(seq, window_width):
+    """
+    Returns a sliding window (of width n) over data from the iterable
+    s -> (s0,s1,...s[n-1]), (s1,s2,...,sn), ...
+
+    Taken from: https://stackoverflow.com/questions/6822725/rolling-or-sliding-window-iterator
+    """
+
+    # it = s0, s1, ...,
+    it = iter(seq)
+
+    # islice just takes the first n terms
+    # Therefore it iterates through the first n terms of it
+    # result = (it0, it1, ... itn)
+    result = tuple(itertools.islice(it, window_width))
+
+    # yield the first result
+    if len(result) == window_width:
+        yield result
+        # it = s[n+1], s[n+2], ...
+        # result = (it0, it1, ... itn) = (s0, s1, ..., sn)
+
+    # Iteratively drop the first term of result and append the first elem of 'it' to results
+    for elem in it:
+        result = result[1:] + (elem,)
+        yield result


### PR DESCRIPTION
This pull request aims to reduce the memory burden of the function 'roll_time_series' by moving the rolling window capability within the TsData classes (currently only WideTsFrameAdapter) as a generator. 
It also adds a helper function 'window' and a small change was made to the '_do_extraction' function so that the dtype of column_id was provided by the TsData object.