### PR TITLE
Fix test failure with newer pandas version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ We changed the default branch from "master" to "main".
     - Fix in the forecasting notebook (#729)
     - Let tsfresh choose the value column if possible (#722)
     - Move from coveralls github action to codecov (#734)
+    - Fix for newer, more strict pandas versions (#737)
 
 Version 0.16.0
 ==============

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -796,7 +796,7 @@ class MakeForecastingFrameTestCase(TestCase):
                                                            kind="test", max_timeshift=1, rolling_direction=1)
 
         expected_y = pd.Series(data=[1, 2, 3], index=pd.DatetimeIndex(["2011-01-01 01:00:00", "2011-01-01 02:00:00",
-                                                                       "2011-01-01 03:00:00"]), name="value")
+                                                                       "2011-01-01 03:00:00"], freq="H"), name="value")
         expected_df = pd.DataFrame({"id": list(zip(["id"] * 3, pd.DatetimeIndex(["2011-01-01 01:00:00",
                                                                                  "2011-01-01 02:00:00",
                                                                                  "2011-01-01 03:00:00"]))),


### PR DESCRIPTION
That should remove a failure which comes up in newer pandas versions because the testing is more strict.