### PR TITLE
Fix the failure with the latest statsmodels installed

### DIFF
--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -447,7 +447,7 @@ def partial_autocorrelation(x, param):
         # https://github.com/statsmodels/statsmodels/pull/6846
         # PACF limits lag length to 50% of sample size.
         if max_demanded_lag >= n // 2:
-            max_lag = n // 2 - (n % 2 == 0)
+            max_lag = n // 2 - 1
         else:
             max_lag = max_demanded_lag
         pacf_coeffs = list(pacf(x, method="ld", nlags=max_lag))

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -444,8 +444,10 @@ def partial_autocorrelation(x, param):
     if n <= 1:
         pacf_coeffs = [np.nan] * (max_demanded_lag + 1)
     else:
-        if (n <= max_demanded_lag):
-            max_lag = n - 1
+        # https://github.com/statsmodels/statsmodels/pull/6846
+        # PACF limits lag length to 50% of sample size.
+        if max_demanded_lag >= n // 2:
+            max_lag = n // 2 - (n % 2 == 0)
         else:
             max_lag = max_demanded_lag
         pacf_coeffs = list(pacf(x, method="ld", nlags=max_lag))

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -450,8 +450,11 @@ def partial_autocorrelation(x, param):
             max_lag = n // 2 - 1
         else:
             max_lag = max_demanded_lag
-        pacf_coeffs = list(pacf(x, method="ld", nlags=max_lag))
-        pacf_coeffs = pacf_coeffs + [np.nan] * max(0, (max_demanded_lag - max_lag))
+        if max_lag > 0:
+            pacf_coeffs = list(pacf(x, method="ld", nlags=max_lag))
+            pacf_coeffs = pacf_coeffs + [np.nan] * max(0, (max_demanded_lag - max_lag))
+        else:
+            pacf_coeffs = [np.nan] * (max_demanded_lag + 1)
 
     return [("lag_{}".format(lag["lag"]), pacf_coeffs[lag["lag"]]) for lag in param]
 


### PR DESCRIPTION
As described in https://github.com/statsmodels/statsmodels/pull/6846, PACF limits lag length to 50% of sample size, this PR follows the behavior to make it works well with the latest statsmodels version.

Fixes #748 if merged.