### PR TITLE
Update relevant_feature_augmenter.py

### DIFF
--- a/tests/units/transformers/test_relevant_feature_augmenter.py
+++ b/tests/units/transformers/test_relevant_feature_augmenter.py
@@ -81,7 +81,7 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         self.assertEqual(sum(["pre_feature" == column for column in transformed_X.columns]), 1)
         self.assertEqual(sum(["pre_feature" == column for column in fit_transformed_X.columns]), 1)
 
-    def filter_only_tsfresh_features_false(self):
+    def test_filter_only_tsfresh_features_false(self):
         """
         The boolean flag `filter_only_tsfresh_features` makes sure that only the time series based features are
         filtered. This unit tests checks that

--- a/tests/units/transformers/test_relevant_feature_augmenter.py
+++ b/tests/units/transformers/test_relevant_feature_augmenter.py
@@ -37,6 +37,7 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         y = pd.Series(dtype="float64")
 
         self.assertRaises(RuntimeError, augmenter.fit, X, y)
+        self.assertRaises(RuntimeError, augmenter.fit_transform, X, y)
 
     def test_nothing_relevant(self):
         augmenter = RelevantFeatureAugmenter(kind_to_fc_parameters=self.kind_to_fc_parameters,
@@ -48,15 +49,18 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
 
         augmenter.set_timeseries_container(self.test_df)
         augmenter.fit(X, y)
-
         transformed_X = augmenter.transform(X.copy())
+
+        fit_transformed_X = augmenter.fit_transform(X, y)
 
         self.assertEqual(list(transformed_X.columns), [])
         self.assertEqual(list(transformed_X.index), list(X.index))
+        self.assertEqual(list(fit_transformed_X.columns), [])
+        self.assertEqual(list(fit_transformed_X.index), list(X.index))
 
-    def test_evaluate_only_added_features_true(self):
+    def test_filter_only_tsfresh_features_true(self):
         """
-        The boolean flag `evaluate_only_extracted_features` makes sure that only the time series based features are
+        The boolean flag `filter_only_tsfresh_features` makes sure that only the time series based features are
         filtered. This unit tests checks that
         """
 
@@ -72,11 +76,14 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         augmenter.fit(X, y)
         transformed_X = augmenter.transform(X.copy())
 
-        self.assertEqual(sum(["pre_feature" == column for column in transformed_X.columns]), 1)
+        fit_transformed_X = augmenter.fit_transform(X, y)
 
-    def test_evaluate_only_added_features_false(self):
+        self.assertEqual(sum(["pre_feature" == column for column in transformed_X.columns]), 1)
+        self.assertEqual(sum(["pre_feature" == column for column in fit_transformed_X.columns]), 1)
+
+    def filter_only_tsfresh_features_false(self):
         """
-        The boolean flag `evaluate_only_extracted_features` makes sure that only the time series based features are
+        The boolean flag `filter_only_tsfresh_features` makes sure that only the time series based features are
         filtered. This unit tests checks that
         """
 
@@ -93,8 +100,12 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
         augmenter.fit(X, y)
         transformed_X = augmenter.transform(X.copy())
 
+        fit_transformed_X = augmenter.fit_transform(X, y)
+
         self.assertEqual(sum(["pre_keep" == column for column in transformed_X.columns]), 1)
         self.assertEqual(sum(["pre_drop" == column for column in transformed_X.columns]), 0)
+        self.assertEqual(sum(["pre_keep" == column for column in fit_transformed_X.columns]), 1)
+        self.assertEqual(sum(["pre_drop" == column for column in fit_transformed_X.columns]), 0)
 
     @mock.patch('tsfresh.transformers.feature_selector.calculate_relevance_table')
     def test_does_impute(self, calculate_relevance_table_mock):
@@ -124,6 +135,8 @@ class RelevantFeatureAugmenterTestCase(DataTestCase):
 
         self.assertRaisesRegex(AttributeError, r"The ids of the time series container",
                                augmenter.fit, X_with_wrong_ids, y)
+        self.assertRaisesRegex(AttributeError, r"The ids of the time series container",
+                               augmenter.fit_transform, X_with_wrong_ids, y)
 
 
 def test_relevant_augmentor_cross_validated():

--- a/tsfresh/transformers/relevant_feature_augmenter.py
+++ b/tsfresh/transformers/relevant_feature_augmenter.py
@@ -333,10 +333,12 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         """
         X_augmented = self._fit_and_augment(X, y)
 
+        selected_features = X_augmented.copy().loc[:, self.feature_selector.relevant_features]
+
         if self.filter_only_tsfresh_features:
-            return X_augmented.copy().loc[:, self.feature_selector.relevant_features + X.columns.tolist()]
-        else:
-            return X_augmented.copy().loc[:, self.feature_selector.relevant_features]
+            selected_features = pd.merge(selected_features, X, left_index=True, right_index=True, how="left")
+
+        return selected_features
 
     def _fit_and_augment(self, X, y):
         """
@@ -350,8 +352,9 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         :param y: The target vector to define, which features are relevant.
         :type y: pandas.Series or numpy.array
 
-        :return: the fitted estimator with the information, which features are relevant.
-        :rtype: RelevantFeatureAugmenter
+        :return: a data sample with the extraced time series features. If filter_only_tsfresh_features is False
+            the data sample will also include the information in X.
+        :rtype: pandas.DataFrame
         """
         if self.timeseries_container is None:
             raise RuntimeError("You have to provide a time series using the set_timeseries_container function before.")

--- a/tsfresh/transformers/relevant_feature_augmenter.py
+++ b/tsfresh/transformers/relevant_feature_augmenter.py
@@ -333,12 +333,10 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         """
         X_augmented = self._fit_and_augment(X, y)
 
-        selected_features = X_augmented.copy().loc[:, self.feature_selector.relevant_features]
-
         if self.filter_only_tsfresh_features:
-            selected_features = pd.merge(selected_features, X, left_index=True, right_index=True, how="left")
-
-        return selected_features
+            return X_augmented.copy().loc[:, self.feature_selector.relevant_features + X.columns.tolist()]
+        else:
+            return X_augmented.copy().loc[:, self.feature_selector.relevant_features]
 
     def _fit_and_augment(self, X, y):
         """
@@ -352,9 +350,8 @@ class RelevantFeatureAugmenter(BaseEstimator, TransformerMixin):
         :param y: The target vector to define, which features are relevant.
         :type y: pandas.Series or numpy.array
 
-        :return: a data sample with the extraced time series features. If filter_only_tsfresh_features is False
-            the data sample will also include the information in X.
-        :rtype: pandas.DataFrame
+        :return: the fitted estimator with the information, which features are relevant.
+        :rtype: RelevantFeatureAugmenter
         """
         if self.timeseries_container is None:
             raise RuntimeError("You have to provide a time series using the set_timeseries_container function before.")


### PR DESCRIPTION
Fix bug in fit_transform() where filter_only_tsfresh_features is True and X is not empty. In this case, X_augmented does not include X.columns (inspect _fit_and_augment() output) resulting in pandas error: 'Passing list-likes to .loc or [] with any missing labels is no longer supported'. The changes in this commit fix this bug without hurting the other cases.
Also, change the description of _fit_and_augment() so that it matches the returned value, X_augmented