### PR TITLE
First test implementation of a matrix_profile feature

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scikit-learn>=0.19.2
 tqdm>=4.10.0
 dask[dataframe]>=2.9.0
 distributed>=2.11.0
+matrixprofile>=1.1.6

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -152,7 +152,9 @@ class ComprehensiveFCParameters(dict):
             "lempel_ziv_complexity": [{"bins": x} for x in [2, 3, 5, 10, 100]],
             "fourier_entropy":  [{"bins": x} for x in [2, 3, 5, 10, 100]],
             "permutation_entropy":  [{"tau": 1, "dimension": x} for x in [3, 4, 5, 6, 7]],
-
+            # TODO: also the window parameter?
+            "matrix_profile": [{"sample_pct": 1, "threshold": 0.98, "feature": f}
+                               for f in ["min", "max", "mean", "median", "25", "75"]]
         })
 
         super().__init__(name_to_param)


### PR DESCRIPTION
Fixes #785 

Sorry it took so long for the first draft...

This is the draft for including matrixprofile in tsfresh. See #785 for more information and still remaining issues.
@vanbenschoten and @tylerwmarrs, I have some questions (also mentioned in the code):

* Currently I calculate using a single call to `compute` the following features:
```
F_x__matrix_profile__feature_"min"__sample_pct_...  0.000000
F_x__matrix_profile__feature_"max"__sample_pct_...  3.255922
F_x__matrix_profile__feature_"mean"__sample_pct...  2.003147
F_x__matrix_profile__feature_"median"__sample_p...  2.134084
F_x__matrix_profile__feature_"25"__sample_pct_1...  1.683442
F_x__matrix_profile__feature_"75"__sample_pct_1...  2.447564
```
  Is this ok as a first draft?
* In principle a user would be able to change all settings of the call to `compute` via tsfreshs setting objects. Currently, I set sample_pct and threshold explicitely to the default parameters of mp, to make it more explicit. Does this make sense?
* I have removed all NaN and Inf from the matrix profile before calculating max min etc. Sounds reasonable?

Of course, we should add tests before merging :-)
