### PR TITLE
Enable multiprocessing only for n_jobs > 1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 
 tsfresh uses `Semantic Versioning <http://semver.org/>`_
 
+Unreleased
+==========
+
+- Bugfixes:
+    - Disable multiprocessing for `n_jobs=1` (#852)
+
 Version 0.18.0
 ==============
 

--- a/tests/units/feature_extraction/test_extraction.py
+++ b/tests/units/feature_extraction/test_extraction.py
@@ -199,7 +199,7 @@ class ExtractionTestCase(DataTestCase):
 
         features_parallel = extract_features(df, column_id="id", column_sort="sort",
                                              column_kind="kind", column_value="val",
-                                             n_jobs=self.n_jobs)
+                                             n_jobs=2)
 
         features_serial = extract_features(df, column_id="id", column_sort="sort",
                                            column_kind="kind", column_value="val",

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -233,7 +233,7 @@ def _do_extraction(df, column_id, column_value, column_kind, column_sort,
 
     if distributor is None:
         if isinstance(data, Iterable):
-            if n_jobs <= 1:
+            if n_jobs == 0 or n_jobs == 1:
                 distributor = MapDistributor(disable_progressbar=disable_progressbar,
                                              progressbar_title="Feature Extraction")
             else:

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -233,7 +233,7 @@ def _do_extraction(df, column_id, column_value, column_kind, column_sort,
 
     if distributor is None:
         if isinstance(data, Iterable):
-            if n_jobs == 0:
+            if n_jobs <= 1:
                 distributor = MapDistributor(disable_progressbar=disable_progressbar,
                                              progressbar_title="Feature Extraction")
             else:

--- a/tsfresh/feature_selection/relevance.py
+++ b/tsfresh/feature_selection/relevance.py
@@ -192,7 +192,7 @@ def calculate_relevance_table(
         else:
             warnings.simplefilter("default")
 
-        if n_jobs == 0:
+        if n_jobs <= 1:
             map_function = map
         else:
             pool = Pool(

--- a/tsfresh/feature_selection/relevance.py
+++ b/tsfresh/feature_selection/relevance.py
@@ -227,7 +227,7 @@ def calculate_relevance_table(
             )
 
         if len(table_const) == len(relevance_table):
-            if n_jobs != 0:
+            if n_jobs > 1:
                 pool.close()
                 pool.terminate()
                 pool.join()
@@ -294,7 +294,7 @@ def calculate_relevance_table(
                 map_function,
             )
 
-        if n_jobs != 0:
+        if n_jobs > 1:
             pool.close()
             pool.terminate()
             pool.join()

--- a/tsfresh/feature_selection/relevance.py
+++ b/tsfresh/feature_selection/relevance.py
@@ -192,7 +192,7 @@ def calculate_relevance_table(
         else:
             warnings.simplefilter("default")
 
-        if n_jobs <= 1:
+        if n_jobs == 0 or n_jobs == 1:
             map_function = map
         else:
             pool = Pool(
@@ -227,7 +227,7 @@ def calculate_relevance_table(
             )
 
         if len(table_const) == len(relevance_table):
-            if n_jobs > 1:
+            if n_jobs < 0 or n_jobs > 1:
                 pool.close()
                 pool.terminate()
                 pool.join()
@@ -294,7 +294,7 @@ def calculate_relevance_table(
                 map_function,
             )
 
-        if n_jobs > 1:
+        if n_jobs < 0 or n_jobs > 1:
             pool.close()
             pool.terminate()
             pool.join()

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -483,7 +483,7 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
         range_of_shifts = range(1, prediction_steps + 1, rolling_amount)
 
     if distributor is None:
-        if n_jobs <= 1:
+        if n_jobs == 0 or n_jobs == 1:
             distributor = MapDistributor(disable_progressbar=disable_progressbar,
                                          progressbar_title="Rolling")
         else:

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -483,7 +483,7 @@ def roll_time_series(df_or_dict, column_id, column_sort=None, column_kind=None,
         range_of_shifts = range(1, prediction_steps + 1, rolling_amount)
 
     if distributor is None:
-        if n_jobs == 0:
+        if n_jobs <= 1:
             distributor = MapDistributor(disable_progressbar=disable_progressbar,
                                          progressbar_title="Rolling")
         else:


### PR DESCRIPTION
After several months away from TSFRESH, I updated to the latest version and encountered some very length error messages. It seemed like the messages were due to multiprocessing, so I set `n_jobs` in `RelevantFeatureAugmentor` to 1 thinking that would fix it by forcing single processing. It didn't fix it, and after some docs reading I discovered `n_jobs=0` is actually the way to force single processing. This is a bit un-intuitive, I think. This pull request changes the behavior so `n_jobs=1` will have the same behavior as `n_jobs=0`.

There might be a good reason why `n_jobs=1` should spawn multiprocessing, but this would have saved me a lot of debugging so I thought I'd suggest it.

On an aside, I should probably also figure out why multiprocessing was causing problems, but that's for later.