### PR TITLE
Docs regarding irregular time series 

### DIFF
--- a/docs/text/faq.rst
+++ b/docs/text/faq.rst
@@ -38,3 +38,11 @@ FAQ
 
         Yes! The feature calculators in tsfresh do not care about the sampling frequency.
         You will have to use the second input format, the stacked DataFramed (see :ref:`data-formats-label`)
+
+
+    5. **Does tsfresh support irregularly spaced time series?**
+
+	Yes, but be careful. As its name suggests, the ``column_sort`` (i.e., timestamp) parameter is only used to sort observations. 
+	Beyond sorting, tsfresh does not use the timestamp in calculations. 
+	While many features do not need a timestamp (or only need it for ordering), others will assume that observations are evenly spaced in time (e.g., one second between each observation). 
+	Since tsfresh ignores spacing, care should be taken when selecting features to use with a highly irregular series.

--- a/docs/text/introduction.rst
+++ b/docs/text/introduction.rst
@@ -48,6 +48,7 @@ Currently, tsfresh is not suitable
     * for usage with streaming data (The streaming data mentioned here is usually used for online operations, while time series data is usually used for offline operations. Online operation and offline operation are a pair of relative concepts.)
     * to train models on the features (we do not want to reinvent the wheel, check out the python package
       `scikit-learn <http://scikit-learn.org/stable/>`_ for example)
+    * for usage with highly irregular time series (for many features). Timestamps are used only to order observations. Many features are interval-agnostic (e.g., number of peaks) and can be used with any series. But some features (e.g., linear trend) assume equal spacing in time, and should be used with care when this assumption is not appropriate. 
 
 However, some of these use cases could be implemented, if you have an application in mind, open
 an issue at `<https://github.com/blue-yonder/tsfresh/issues>`_, or feel free to contact us.


### PR DESCRIPTION
Adds paragraphs to intro and faq in docs to further clarify that tsfresh only uses timestamp for ordering, not time intervals.