### PR TITLE
fixed missing datetime for timebased features and allowed warnings to be silenced

### DIFF
--- a/tsfresh/convenience/bindings.py
+++ b/tsfresh/convenience/bindings.py
@@ -8,7 +8,8 @@ import pandas as pd
 
 def _feature_extraction_on_chunk_helper(df, column_id, column_kind,
                                         column_sort, column_value,
-                                        default_fc_parameters, kind_to_fc_parameters):
+                                        default_fc_parameters, kind_to_fc_parameters,
+                                        show_warnings= True):
     """
     Helper function wrapped around _do_extraction_on_chunk to use the correct format
     of the "chunk" and output a pandas dataframe.
@@ -23,10 +24,14 @@ def _feature_extraction_on_chunk_helper(df, column_id, column_kind,
 
     if column_sort is not None:
         df = df.sort_values(column_sort)
-
-    chunk = df[column_id].iloc[0], df[column_kind].iloc[0], df[column_value]
+        data = df[[column_sort,column_value]].set_index(column_sort)
+    else: 
+        data = df[column_value]
+        
+    chunk = df[column_id].iloc[0], df[column_kind].iloc[0], data
     features = _do_extraction_on_chunk(chunk, default_fc_parameters=default_fc_parameters,
-                                       kind_to_fc_parameters=kind_to_fc_parameters)
+                                       kind_to_fc_parameters=kind_to_fc_parameters,
+                                       show_warnings = show_warnings)
     features = pd.DataFrame(features, columns=[column_id, "variable", "value"])
     features["value"] = features["value"].astype("double")
 
@@ -35,7 +40,8 @@ def _feature_extraction_on_chunk_helper(df, column_id, column_kind,
 
 def dask_feature_extraction_on_chunk(df, column_id, column_kind,
                                      column_value, column_sort=None,
-                                     default_fc_parameters=None, kind_to_fc_parameters=None):
+                                     default_fc_parameters=None, kind_to_fc_parameters=None,
+                                     show_warnings = True):
     """
     Extract features on a grouped dask dataframe given the column names and the extraction settings.
     This wrapper function should only be used if you have a dask dataframe as input.
@@ -119,7 +125,8 @@ def dask_feature_extraction_on_chunk(df, column_id, column_kind,
                                  column_id=column_id, column_kind=column_kind,
                                  column_sort=column_sort, column_value=column_value,
                                  default_fc_parameters=default_fc_parameters,
-                                 kind_to_fc_parameters=kind_to_fc_parameters)
+                                 kind_to_fc_parameters=kind_to_fc_parameters,
+                                 show_warnings = show_warnings)
     return df.apply(feature_extraction, meta=[(column_id, 'int64'), ('variable', 'object'), ('value', 'float64')])
 
 

--- a/tsfresh/feature_extraction/extraction.py
+++ b/tsfresh/feature_extraction/extraction.py
@@ -314,7 +314,7 @@ def _do_extraction_on_chunk(chunk, default_fc_parameters, kind_to_fc_parameters,
                         continue
                 x = data
             else:
-                x = data.values
+                x = data.values.flatten()
 
             if getattr(func, "fctype", None) == "combiner":
                 result = func(x, param=parameter_list)

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -2207,7 +2207,7 @@ def linear_trend_timewise(x, param):
     times_seconds = (ix - ix[0]).total_seconds()
     times_hours = np.asarray(times_seconds / float(3600))
 
-    linReg = linregress(times_hours, x.values)
+    linReg = linregress(times_hours, x.values.flatten())
 
     return [("attr_\"{}\"".format(config["attr"]), getattr(linReg, config["attr"]))
             for config in param]


### PR DESCRIPTION
dask_feature_extraction_on_chunk did not forwardthe sort_by column as index to the time dependend feastures such al 'linear_trend_timewise. Also The option to forbid warnings has been added 'dask_feature_extraction_on_chunk'