### PR TITLE
Multiple Group IDs for rolling_time_series

### DIFF
--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -397,8 +397,8 @@ def roll_time_series(
     :type df_or_dict: pandas.DataFrame or dict
 
     :param column_id: it must be present in the pandas DataFrame or in all DataFrames in the dictionary.
-        It is not allowed to have NaN values in this column.
-    :type column_id: basestring
+        It is not allowed to have NaN values in this column. Multiple id column names which define together one time series can be passed as well.
+    :type column_id: basestring or list
 
     :param column_sort: if not None, sort the rows by this column. It is not allowed to
         have NaN values in this column. If not given, will be filled by an increasing number,


### PR DESCRIPTION
In some cases you have multiple id columns which define a time series, i.e. factory and machine type (Factory A & Machine A; Factory B & Machine A; ...). You could now create a new single id column beforehand; this would be ideally just a tuple of the combinations. Unfortunately the `rolling_time_series()` function can't handle them right now (at least it didn't work for me).
Therefore I adapted the code a little bit in this function to handle multiple id columns.

Moreover if the column id name is different than "id", i.e. "machine_name", this column is also present in the rolled dataframe after calling `rolling_time_series()`.
```
from tsfresh.utilities.dataframe_functions import roll_time_series
df_rolled = roll_time_series(df, column_id="machine_name", column_sort="time")

from tsfresh import extract_features
df_features = extract_features(df_rolled, column_id="id", column_sort="time")
```
A naive user (like me) would just pass the rolled dataframe directly into the extract_features function. With the above workflow the `extract_features()` function would

- fail if the column "machine_name" contains strings
- would run perfectly and calculate features for "machine_name" if the column contains numerical values -> this doesn't make sense for me as we group indirectly by this column anyway and calculating features for id's...well..

Therefore I dropped the initial id colum(s) in this PR after rolling. The id's are included in the new created "id" and will be easy accessible again after the extracting the features from the rolled dataframe.

I am sure there is a lot of room for improvements in my code changes, but for my use cases it works and I would be happy to get your feedback and thoughts about this.
