### PR TITLE
Use pandas Index.equals in check_if_pandas_series

### DIFF
--- a/tsfresh/feature_selection/significance_tests.py
+++ b/tsfresh/feature_selection/significance_tests.py
@@ -207,7 +207,7 @@ def __check_if_pandas_series(x, y):
         raise TypeError("x should be a pandas Series")
     if not isinstance(y, pd.Series):
         raise TypeError("y should be a pandas Series")
-    if not list(y.index) == list(x.index):
+    if not y.index.equals(x.index): 
         raise ValueError("X and y need to have the same index!")
 
 


### PR DESCRIPTION
The current implementation of checking the index of x and y is very unefficient for large data. Using the Panda function Index.equals solves this. 

![grafik](https://user-images.githubusercontent.com/45793125/183654781-a591b4f2-cb88-49ad-974d-7736e5d98ab3.png)
