### PR TITLE
Add matrix profile as an optional import.

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -2,4 +2,5 @@
 pip install -r requirements.txt
 pip install -r rdocs-requirements.txt
 pip install -r test-requirements.txt
+pip install -r optional-requirements.txt
 pip install -e .

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,0 +1,1 @@
+matrixprofile>=1.1.10,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ scikit-learn>=0.22.0
 tqdm>=4.10.0
 dask[dataframe]>=2.9.0
 distributed>=2.11.0
-matrixprofile>=1.1.10,<2.0.0
 stumpy>=1.7.2
 cloudpickle

--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,7 @@ setup(
     setup_requires=["setuptools_scm"] + sphinx,
     packages=find_packages(exclude=["tests.*", "tests"]),
     install_requires=requirements,
+    extras_require={
+        'matrixprofile': ['matrixprofile>=1.1.10,<2.0.0']
+    }
 )

--- a/tests/units/feature_extraction/test_feature_calculations.py
+++ b/tests/units/feature_extraction/test_feature_calculations.py
@@ -3,11 +3,9 @@
 # Maximilian Christ (maximilianchrist.com), Blue Yonder Gmbh, 2016
 
 import math
-import warnings
+import unittest
 from random import shuffle
 from unittest import TestCase
-
-from matrixprofile.exceptions import NoSolutionPossible
 
 from tsfresh.examples.driftbif_simulation import velocity
 from tsfresh.feature_extraction.feature_calculators import *
@@ -2041,6 +2039,7 @@ class FeatureCalculationTestCase(TestCase):
         param = [{"query": query, "threshold": threshold, "normalize": False}]
         self.assertAlmostEqual(query_similarity_count(x, param=param)[0][1], 91.0)
 
+    @unittest.skipIf(not getattr(matrix_profile, "dependency_available", True), "Missing matrixprofile dependency")
     def test_matrix_profile_window(self):
         # Test matrix profile output with specified window
         np.random.seed(9999)
@@ -2060,6 +2059,7 @@ class FeatureCalculationTestCase(TestCase):
 
         self.assertAlmostEqual(matrix_profile(ts, param=param)[0][1], 2.825786727580335)
 
+    @unittest.skipIf(not getattr(matrix_profile, "dependency_available", True), "Missing matrixprofile dependency")
     def test_matrix_profile_no_window(self):
         # Test matrix profile output with no window specified
         np.random.seed(9999)
@@ -2081,6 +2081,7 @@ class FeatureCalculationTestCase(TestCase):
         # Test matrix profile output with no window specified
         self.assertAlmostEqual(matrix_profile(ts, param=param)[0][1], 2.825786727580335)
 
+    @unittest.skipIf(not getattr(matrix_profile, "dependency_available", True), "Missing matrixprofile dependency")
     def test_matrix_profile_nan(self):
         # Test matrix profile of NaNs (NaN output)
         ts = np.random.uniform(size=2 ** 6)

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -23,16 +23,21 @@ import warnings
 from builtins import range
 from collections import defaultdict
 
-import matrixprofile as mp
 import numpy as np
 import pandas as pd
 import stumpy
-from matrixprofile.exceptions import NoSolutionPossible
 from numpy.linalg import LinAlgError
 from scipy.signal import cwt, find_peaks_cwt, ricker, welch
 from scipy.stats import linregress
 from statsmodels.tools.sm_exceptions import MissingDataError
 from statsmodels.tsa.ar_model import AutoReg
+
+try:
+    import matrixprofile as mp
+    from matrixprofile.exceptions import NoSolutionPossible
+except ImportError:
+    mp = None
+
 
 from tsfresh.utilities.string_manipulation import convert_to_output_format
 
@@ -2363,9 +2368,13 @@ def benford_correlation(x):
 
 
 @set_property("fctype", "combiner")
+@set_property("dependency_available", mp is not None)
 def matrix_profile(x, param):
     """
     Calculates the 1-D Matrix Profile[1] and returns Tukey's Five Number Set plus the mean of that Matrix Profile.
+
+    This feature is not supported anymore, since matrixprofile does not up to date with latest Python releases. To use
+    it, you can install the extra with pip install tsfresh[matrixprofile].
 
     .. rubric:: References
 
@@ -2383,6 +2392,10 @@ def matrix_profile(x, param):
     :return: the different feature values
     :return type: pandas.Series
     """
+    if mp is None:
+        raise ImportError(
+            "Could not import matrixprofile but it was required. Please install the extra to use it."
+        )
 
     x = np.asarray(x)
 

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -5,6 +5,7 @@
 This file contains methods/objects for controlling which features will be extracted when calling extract_features.
 For the naming of the features, see :ref:`feature-naming-label`.
 """
+import logging
 from builtins import range
 from collections import UserDict
 from inspect import getfullargspec
@@ -15,6 +16,8 @@ import pandas as pd
 
 from tsfresh.feature_extraction import feature_calculators
 from tsfresh.utilities.string_manipulation import get_config_from_string
+
+_logger = logging.getLogger(__name__)
 
 
 def from_columns(columns, columns_to_ignore=None):
@@ -252,6 +255,19 @@ class ComprehensiveFCParameters(PickableSettings):
                 ],
             }
         )
+
+        # remove missing dependencies
+        for name, func in feature_calculators.__dict__.items():
+            if (
+                callable(func)
+                and hasattr(func, "fctype")
+                and hasattr(func, "dependency_available")
+                and getattr(func, "dependency_available") is False
+            ):
+                name_to_param.pop(name)
+                _logger.warning(
+                    f"Dependency not available for {name}, this feature will be disabled!"
+                )
 
         super().__init__(name_to_param)
 

--- a/tsfresh/feature_extraction/settings.py
+++ b/tsfresh/feature_extraction/settings.py
@@ -260,7 +260,6 @@ class ComprehensiveFCParameters(PickableSettings):
         for name, func in feature_calculators.__dict__.items():
             if (
                 callable(func)
-                and hasattr(func, "fctype")
                 and hasattr(func, "dependency_available")
                 and getattr(func, "dependency_available") is False
             ):


### PR DESCRIPTION
There are many issues regarding matrixprofile not being supported anymore:

https://github.com/blue-yonder/tsfresh/issues/972
https://github.com/blue-yonder/tsfresh/issues/937
https://github.com/blue-yonder/tsfresh/issues/952
https://github.com/blue-yonder/tsfresh/issues/932

These are all related to the outdated dependency matrixprofile.

This draft MR introduces matrix profile as an optional dependency. It also makes sure many users can run this code in newer versions of python or different cpus.

Could any maintainer take a look?