### PR TITLE
Fix file paths after example notebooks were moved

### DIFF
--- a/docs/text/quick_start.rst
+++ b/docs/text/quick_start.rst
@@ -142,7 +142,7 @@ Further, you can even perform the extraction, imputing and filtering at the same
 You can now use the features in the DataFrame `features_filtered` (which is equal to
 `features_filtered_direct`) in conjunction with `y` to train your classification model.
 You can find an example in the Jupyter notebook
-`01 Feature Extraction and Selection.ipynb <https://github.com/blue-yonder/tsfresh/blob/main/notebooks/examples/01%20Feature%20Extraction%20and%20Selection.ipynb>`_
+`01 Feature Extraction and Selection.ipynb <https://github.com/blue-yonder/tsfresh/blob/main/notebooks/01%20Feature%20Extraction%20and%20Selection.ipynb>`_
 were we train a RandomForestClassifier using the extracted features.
 
 References

--- a/tests/integrations/test_notebooks.py
+++ b/tests/integrations/test_notebooks.py
@@ -70,32 +70,32 @@ def _notebook_run(path, timeout=default_timeout):
 class NotebooksTestCase(TestCase):
     def test_basic_example(self):
         nb, errors = _notebook_run(
-            "notebooks/examples/01 Feature Extraction and Selection.ipynb",
+            "notebooks/01 Feature Extraction and Selection.ipynb",
             default_timeout,
         )
         self.assertEqual(errors, [])
 
     def test_pipeline_example(self):
         nb, errors = _notebook_run(
-            "notebooks/examples/02 sklearn Pipeline.ipynb", default_timeout
+            "notebooks/02 sklearn Pipeline.ipynb", default_timeout
         )
         self.assertEqual(errors, [])
 
     def test_extraction_settings(self):
         nb, errors = _notebook_run(
-            "notebooks/examples/03 Feature Extraction Settings.ipynb", default_timeout
+            "notebooks/03 Feature Extraction Settings.ipynb", default_timeout
         )
         self.assertEqual(errors, [])
 
     def test_multiclass_selection_example(self):
         nb, errors = _notebook_run(
-            "notebooks/examples/04 Multiclass Selection Example.ipynb", default_timeout
+            "notebooks/04 Multiclass Selection Example.ipynb", default_timeout
         )
         self.assertEqual(errors, [])
 
     def test_timeseries_forecasting(self):
         nb, errors = _notebook_run(
-            "notebooks/examples/05 Timeseries Forecasting.ipynb", default_timeout
+            "notebooks/05 Timeseries Forecasting.ipynb", default_timeout
         )
         self.assertEqual(errors, [])
 


### PR DESCRIPTION
Hi there 👋 
The commit 357cf3274b2d2a175e05cb7f9e40d63ae4b8a34a moved all basic examples into the root notebook folder.
References to these notebooks weren't changed yet, leading to an error 404 when clicking on the link from the quick start guide. This PR simply replaces all usages of `notebooks/examples/` with `notebooks/`.