### PR TITLE
Added functionality to test multiple versions of python using tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ tsfresh/notebooks/data/
 # dask
 dask-worker-space
 dask-worker-space/
+
+# python version files
+.python_version
+
+# tox log files
+.tox

--- a/docs/text/how_to_contribute.rst
+++ b/docs/text/how_to_contribute.rst
@@ -67,6 +67,18 @@ you have to:
     pytest
 
 
+To test changes across multiple versions of Python, run:
+
+
+.. code::
+
+    tox -r
+
+
+`tox -r` will execute tests for the Python versions specified in `setup.cfg <https://github.com/blue-yonder/tsfresh/blob/1297c8ca5bd6f8f23b4de50e3f052fb4ec1307f8/setup.cfg>`_ using the `envlist` variable. For example, if `envlist` is set to `py37, py38`, the test suite will run for Python 3.7 and 3.8 on the local development platform, assuming the binaries for those versions are available locally. The exact Python microversions (e.g. `3.7.1` vs `3.7.2`) depend on what is installed on the local development machine.
+
+A recommended way to manage multiple Python versions when testing locally is with `pyenv`, which enables organized installation and switching between versions.
+
 Documentation
 '''''''''''''
 

--- a/docs/text/how_to_contribute.rst
+++ b/docs/text/how_to_contribute.rst
@@ -90,3 +90,9 @@ We use black and isort for styling. They are automatically triggered on every co
 
 
 We are looking forward to hear from you! =)
+
+
+PR Descriptions
+'''''''''''''''
+
+The PR should have a clear and descriptive title, along with a detailed description of the changes made, the problem being addressed, and any relevant tips for reviewers. An example of what this might look like is `here. <https://github.com/blue-yonder/tsfresh/pull/994#issue-1509962136>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -140,3 +140,23 @@ max-line-length = 120
 # This will be used when updating. Do not change!
 version = 3.2.3
 package = tsfresh
+
+[tox:tox]
+# Tox global conifguration options
+minversion = 4.0.0
+# Which python versions to test for
+envlist = py37, py38, py39, py310, py311
+# Don't throw an error if a specific version of python is not installed
+skip_missing_interpreters = True
+# Ensure that tox uses a virtual environment to build a source distribution
+isolated_build = True
+
+# Tox configuration options for each version of python
+[testenv]
+commands =
+    # display the python version that tests are being run on
+    python -V
+    # install package requirements before running tests
+    python -m pip install .[testing]
+    # run the tests
+    python -m pytest tests/


### PR DESCRIPTION
## What functionality changed? ##

This PR adds functionality to be able to locally test multiple versions of python using `tox.`

This PR will run the test suite for python versions 3.7, 3.8, 3.9, 3.10, and 3.11 for whichever platform the user runs the tests on. The specific microversion of python depends on what is installed on the user's machine. 

`tox` will skip over running the test suite for a given version if it cannot find a particular python environment.


## How to run? ##

To test on multiple python versions, edit `envlist` in `setup.cfg` to include the python versions you want to test on, and then run:
```bash
tox -r
``` 
in the top-level directory for tsfresh. Currently the versions being tested span between python 3.7-3.11


## Why? ##

This PR will make it much easier to (locally) test tsfresh against multiple versions of python, for a given platform


## What code changed? ##

`setup.cfg` was changed to include some extra configuration information.

`tox` was added to test-requirements.txt

 
 ## Tips for reviewing/running ##

By default, `tox` will look in binary directories for any relevant python interpreters. For example, if  

```bash 
envlist = (py37, py38)
```
exists in `setup.cfg`, then `tox` will look inside binary directories for python executables named similar to python3.7.X and python 3.8.X. If it cannot find any executables for a given python version, then it will skip over testing that version. 

Note that in this PR:

```bash
envlist = py37, py38, py39, py310, py311
```

But it should also be noted that while included in the envlist, py311 is currently not compatible with tsfresh due to a numba dependency conflict. 

### Using `pyenv` in tandem with `tox` 
A recommended way to handle multiple versions of python is with `pyenv`. `pyenv` will allow you to install multiple versions of python in a well-organised fashion.

If you choose to use `pyenv` to manage the different python versions installed on your machine, then the executables of each python version will be in `~/.pyenv/shims/` which will not be found by `tox` by default. A recommended solution to this is to make a `.python-version` file, with the versions of python that you want `tox` to look for. 

For example, if the output of running

```bash
pyenv versions
``` 

shows that you have installed python 3.7.16 and python 3.8.16, then you should put `3.7.16` and `3.8.16` as separate lines in the `.python-version` file. Running `tox -r` will then run the tests for python3.7.16 and python3.8.16, and `tox` will know where to find the relevant python interpreters. 

##### `pyenv` important note

The python version that the `tox` command is initially invoked from matters! 

Running `pyenv which python` will show the version of python from which the `tox` command will be invoked from. If `tox` is initially invoked from a version of python that is not supported by the package (i.e. package is invoked from python 3.6 and `python_requires` is >=3.7), then `tox` will fail for all environments, _including python versions that would otherwise work if `tox` was originally invoked from a version of python supported with the package._

Note that we can still test tsfresh on unsupported versions of python (such as 3.6), provided that `tox` is initially invoked from a version of python that is in tsfresh `python_requires` (such as 3.8).


### Log files

Log files are stored in the `.tox` directory which is created once `tox` is run.  