### PR TITLE
Replace hard-coded "id" with column_id in `roll_time_series`

### DIFF
--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -343,7 +343,7 @@ def _roll_out_time_series(
         else:
             timeshift_value = timeshift - 1
         # and now create new ones ids out of the old ones
-        df_temp["id"] = df_temp[column_id].apply(lambda row: (row, timeshift_value))
+        df_temp[column_id] = df_temp[column_id].apply(lambda row: (row, timeshift_value))
 
         return df_temp
 


### PR DESCRIPTION
This fixes the inconsistency of `roll_time_series` aways naming the resulting tuple index as "id" even if the user passes and alternative `id` via the column_id parameter.