### PR TITLE
Make tsfresh compatible with numpy 1.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.9.1
-numpy >=1.15.1, <1.24
+numpy >=1.15.1
 pandas>=0.25.0
 scipy>=1.2.0
 statsmodels>=0.13

--- a/tests/integrations/examples/test_robot_execution_failures.py
+++ b/tests/integrations/examples/test_robot_execution_failures.py
@@ -54,4 +54,4 @@ class RobotExecutionFailuresTestCase(TestCase):
         )
 
         assert len(y.unique()) > 2
-        assert y.dtype == np.object
+        assert y.dtype == object

--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -25,7 +25,8 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
-import stumpy
+
+# import stumpy
 from numpy.linalg import LinAlgError
 from scipy.signal import cwt, find_peaks_cwt, ricker, welch
 from scipy.stats import linregress

--- a/tsfresh/feature_selection/relevance.py
+++ b/tsfresh/feature_selection/relevance.py
@@ -360,7 +360,7 @@ def infer_ml_task(y):
     :return: 'classification' or 'regression'
     :rtype: str
     """
-    if y.dtype.kind in np.typecodes["AllInteger"] or y.dtype == np.object:
+    if y.dtype.kind in np.typecodes["AllInteger"] or y.dtype == object:
         ml_task = "classification"
     else:
         ml_task = "regression"

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -506,7 +506,7 @@ def roll_time_series(
 
         df = df.sort_values(column_sort)
 
-        if df[column_sort].dtype != np.object:
+        if df[column_sort].dtype != object:
             # if rolling is enabled, the data should be uniformly sampled in this column
             # Build the differences between consecutive time sort values
 


### PR DESCRIPTION
Related to #1017.

Remove all `np.object` which are deprecated in the newest numpy.
Please note that since `numba` (needed by `stumpy`) is not compatible with the newest `numpy`, this makes `tsfresh` itself not compatible with it yet. But once `numba` releases, this will automatically happen.