### PR TITLE
View and Set N Jobs

### DIFF
--- a/tests/units/utilities/test_distribution.py
+++ b/tests/units/utilities/test_distribution.py
@@ -30,6 +30,9 @@ class MultiprocessingDistributorTestCase(TestCase):
         set_n_jobs(4)
         self.assertEqual(4, get_n_jobs())
 
+        set_n_jobs(curr)
+        self.assertEqual(curr, get_n_jobs())
+
     def test_partition(self):
 
         distributor = MultiprocessingDistributor(n_workers=1)

--- a/tests/units/utilities/test_distribution.py
+++ b/tests/units/utilities/test_distribution.py
@@ -16,9 +16,20 @@ from tsfresh.utilities.distribution import (
     LocalDaskDistributor,
     MultiprocessingDistributor,
 )
+from tsfresh.utilities.profiling import get_n_jobs, set_n_jobs
 
 
 class MultiprocessingDistributorTestCase(TestCase):
+    def test_n_jobs(self):
+        curr = get_n_jobs()
+        self.assertEqual(curr, get_n_jobs())
+
+        set_n_jobs(2)
+        self.assertEqual(2, get_n_jobs())
+
+        set_n_jobs(4)
+        self.assertEqual(4, get_n_jobs())
+
     def test_partition(self):
 
         distributor = MultiprocessingDistributor(n_workers=1)

--- a/tsfresh/utilities/profiling.py
+++ b/tsfresh/utilities/profiling.py
@@ -10,7 +10,7 @@ import io
 import logging
 import pstats
 
-import tsfresh.defaults as defaults
+from tsfresh import defaults
 
 _logger = logging.getLogger(__name__)
 

--- a/tsfresh/utilities/profiling.py
+++ b/tsfresh/utilities/profiling.py
@@ -10,6 +10,8 @@ import io
 import logging
 import pstats
 
+import tsfresh.defaults as defaults
+
 _logger = logging.getLogger(__name__)
 
 
@@ -66,3 +68,26 @@ def end_profiling(profiler, filename, sorting=None):
             "[calculate_ts_features] Finished profiling of time series feature extraction"
         )
         f.write(s.getvalue())
+
+
+def get_n_jobs():
+    """
+    Get the number of jobs to use for parallel processing.
+
+    :return: The number of jobs to use for parallel processing.
+    :rtype: int
+    """
+    return defaults.N_PROCESSES
+
+
+def set_n_jobs(n_jobs):
+    """
+    Set the number of jobs to use for parallel processing.
+
+    :param n_jobs: The number of jobs to use for parallel processing.
+    :type n_jobs: int
+
+    :return: None
+    :rtype: None
+    """
+    defaults.N_PROCESSES = n_jobs


### PR DESCRIPTION
### Reason for PR:

When profiling specific functions, it is often helpful to have more fine-grained control over the `N_PROCESSES` constant used in multiprocessing. 


### PR Description:

Getter and setter functions for the `N_PROCESSES` constant found with the other default constants.