### PR TITLE
RayDistributor for using Ray to distribute the calculations in tsfresh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3
         exclude: "^docs/.*$"
   - repo: https://github.com/pycqa/isort
-    rev: 5.7.0
+    rev: 5.12.0
     hooks:
       - id: isort
         args:

--- a/docs/text/tsfresh_on_a_cluster.rst
+++ b/docs/text/tsfresh_on_a_cluster.rst
@@ -200,6 +200,56 @@ of 3 workers:
                          column_sort='time',
                          distributor=Distributor)
 
+Using Ray to distribute the calculations
+'''''''''''''''''''''''''''''''''''''''''
+We provide a Distributor for the `Ray framework <https://docs.ray.io/en/latest/index.html>`_, where
+*"Ray is an open-source unified compute framework that makes it easy to scale AI and Python workloads."*
+
+.. NOTE::
+    Ray is an optional dependency and users who needs to use Ray to distribute the calculations should install
+    it first by `pip install ray`.
+
+Ray is a easy-to-use developing framework for distributed computing workload. Users could use it on single node or scale
+to a cluster. Users only need to have an address of the Ray cluster to connect to (e.g., "ray://123.45.67.89:10001").
+
+.. code:: python
+
+    from tsfresh.examples.robot_execution_failures import \
+        download_robot_execution_failures, \
+        load_robot_execution_failures
+    from tsfresh.feature_extraction import extract_features
+    from tsfresh.utilities.distribution import RayDistributor
+
+    download_robot_execution_failures()
+    df, y = load_robot_execution_failures()
+
+    Distributor = RayDistributor(address="ray://123.45.67.89:10001")
+
+    X = extract_features(timeseries_container=df,
+                         column_id='id',
+                         column_sort='time',
+                         distributor=Distributor)
+
+If users would like to have a local cluster with multiple workers. They could simply leave `address`` unset.
+
+.. code:: python
+
+    from tsfresh.examples.robot_execution_failures import \
+        download_robot_execution_failures, \
+        load_robot_execution_failures
+    from tsfresh.feature_extraction import extract_features
+    from tsfresh.utilities.distribution import RayDistributor
+
+    download_robot_execution_failures()
+    df, y = load_robot_execution_failures()
+
+    Distributor = RayDistributor(n_workers=3)
+
+    X = extract_features(timeseries_container=df,
+                         column_id='id',
+                         column_sort='time',
+                         distributor=Distributor)
+
 Writing your own distributor
 ''''''''''''''''''''''''''''
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,4 +8,6 @@ seaborn>=0.7.1
 ipython>=5.3.0
 notebook>=4.4.1
 pandas-datareader>=0.5.0
+ray>=2.5.0
+protobuf<=3.20.3
 pre-commit

--- a/tests/units/utilities/test_distribution.py
+++ b/tests/units/utilities/test_distribution.py
@@ -15,6 +15,7 @@ from tsfresh.utilities.distribution import (
     ClusterDaskDistributor,
     LocalDaskDistributor,
     MultiprocessingDistributor,
+    RayDistributor,
 )
 
 
@@ -189,3 +190,70 @@ class ClusterDaskDistributorTestCase(DataTestCase):
         self.assertTrue(np.all(extracted_features.b__mean == np.array([37.85, 34.75])))
         self.assertTrue(np.all(extracted_features.b__median == np.array([39.5, 28.0])))
         cluster.close()
+
+
+# RayDistributor
+class LocalRayDistributorTestCase(DataTestCase):
+    def test_ray_cluster_extraction_one_worker(self):
+
+        Distributor = RayDistributor(n_workers=1)
+
+        df = self.create_test_data_sample()
+        extracted_features = extract_features(
+            df,
+            column_id="id",
+            column_sort="sort",
+            column_kind="kind",
+            column_value="val",
+            distributor=Distributor,
+        )
+
+        self.assertIsInstance(extracted_features, pd.DataFrame)
+        self.assertTrue(np.all(extracted_features.a__maximum == np.array([71, 77])))
+        self.assertTrue(
+            np.all(extracted_features.a__sum_values == np.array([691, 1017]))
+        )
+        self.assertTrue(
+            np.all(extracted_features.a__abs_energy == np.array([32211, 63167]))
+        )
+        self.assertTrue(
+            np.all(extracted_features.b__sum_values == np.array([757, 695]))
+        )
+        self.assertTrue(np.all(extracted_features.b__minimum == np.array([3, 1])))
+        self.assertTrue(
+            np.all(extracted_features.b__abs_energy == np.array([36619, 35483]))
+        )
+        self.assertTrue(np.all(extracted_features.b__mean == np.array([37.85, 34.75])))
+        self.assertTrue(np.all(extracted_features.b__median == np.array([39.5, 28.0])))
+
+    def test_ray_cluster_extraction_two_worker(self):
+
+        Distributor = RayDistributor(n_workers=2)
+
+        df = self.create_test_data_sample()
+        extracted_features = extract_features(
+            df,
+            column_id="id",
+            column_sort="sort",
+            column_kind="kind",
+            column_value="val",
+            distributor=Distributor,
+        )
+
+        self.assertIsInstance(extracted_features, pd.DataFrame)
+        self.assertTrue(np.all(extracted_features.a__maximum == np.array([71, 77])))
+        self.assertTrue(
+            np.all(extracted_features.a__sum_values == np.array([691, 1017]))
+        )
+        self.assertTrue(
+            np.all(extracted_features.a__abs_energy == np.array([32211, 63167]))
+        )
+        self.assertTrue(
+            np.all(extracted_features.b__sum_values == np.array([757, 695]))
+        )
+        self.assertTrue(np.all(extracted_features.b__minimum == np.array([3, 1])))
+        self.assertTrue(
+            np.all(extracted_features.b__abs_energy == np.array([36619, 35483]))
+        )
+        self.assertTrue(np.all(extracted_features.b__mean == np.array([37.85, 34.75])))
+        self.assertTrue(np.all(extracted_features.b__median == np.array([39.5, 28.0])))


### PR DESCRIPTION
Ray is getting popular for building distributed applications and easy to fit into tsfresh by a `RayDistributor`.

# Distributed tsfresh on Ray
This repo involves a new `RayDistributor` for tsfresh to use ray to distribute the calculations.

`RayDistributor` is a subclass of `IterableDistributorBaseClass` in tsfresh which follows the developing instruction in https://tsfresh.readthedocs.io/en/latest/text/tsfresh_on_a_cluster.html.

## Quick Start
Use `RayDistributor` the same way as `MultiprocessingDistributor`, `ClusterDaskDistributor` or `LocalDaskDistributor`.
```python
from tsfresh.utilities.distribution import RayDistributor

distributor = RayDistributor(n_workers=4)
# ...
extracted_features = extract_features(..., distributor=distributor)
# ...
```

## Code change summary
- add `RayDistributor` definition in tsfresh.utilities.distribution
- add `RayDistributor` document in docs/text/tsfresh_on_a_cluster.rst
- Update pre-commit-config to enable future development
- Update test-requirements.txt for UT
- munually test the UT and document generation locally