### PR TITLE
Extra notes on parallelization efficiencies

### DIFF
--- a/docs/text/faq.rst
+++ b/docs/text/faq.rst
@@ -46,3 +46,7 @@ FAQ
 	Beyond sorting, tsfresh does not use the timestamp in calculations.
 	While many features do not need a timestamp (or only need it for ordering), others will assume that observations are evenly spaced in time (e.g., one second between each observation).
 	Since tsfresh ignores spacing, care should be taken when selecting features to use with a highly irregular series.
+
+    6. **Even when just extracing the :class:`tsfresh.feature_extraction.settings.EfficientFCParameters`, tsfresh is taking a long time to run. Is there anything further I can do to speed up the processing?**
+
+	If you are using Parallelization (the default option), you may need to check you are not over-provisioning your avaiable cpu cores. Take a look at :ref:`notes-for-efficient-parallelization-label` for steps to eliminate this, which can speed up processing significantly.

--- a/docs/text/tsfresh_on_a_cluster.rst
+++ b/docs/text/tsfresh_on_a_cluster.rst
@@ -230,7 +230,7 @@ The environment variables in question are, `OMP_NUM_THREADS`, `MKL_NUM_THREADS` 
     os.environ['MKL_NUM_THREADS'] = "1"
     os.environ['OPENBLAS_NUM_THREADS'] = "1"
 
-To run the notebook successfully it is then required to use the 'Restart the kernel' option.
+Put these lines at the beginning of your notebook/python script - before you call any tsfresh code or import any other module.
 
 The more cores your host computer has, the more improvement in processing speed will be gained by implementing these environment changes. Speed increases of between 6x and 26x have been observed depending on the type of the host machine.
 

--- a/docs/text/tsfresh_on_a_cluster.rst
+++ b/docs/text/tsfresh_on_a_cluster.rst
@@ -213,7 +213,7 @@ Notes for efficient parallelization
 
 By default tsfresh uses parallelization to distribute the single-threaded python code to the multiple cores available on the host machine.
 
-However, this can create an issue known as over-provisioning, due to the fact that many of the underlying python libraries this project is built upon drop back into C code implementations for their low-level processing, and `also` try and spread their workload between as many threads/cores available.
+However, this can create an issue known as over-provisioning. Many of the underlying python libraries (e.g. numpy) used in the feature calculators have C code implementations for their low-level processing. Those `also` try to spread their workload between as many cores available - which is in conflict with the parallelization done by tsfresh.
 
 Over-provisioning is inefficient because of the overheads of repeated context switching. 
 

--- a/docs/text/tsfresh_on_a_cluster.rst
+++ b/docs/text/tsfresh_on_a_cluster.rst
@@ -217,11 +217,7 @@ However, this can create an issue known as over-provisioning. Many of the underl
 
 Over-provisioning is inefficient because of the overheads of repeated context switching. 
 
-It is far better to give control over this load distribution to the larger tasks, hence using parallelization in tsfresh, but to make best use of this and stop the over-provisioning of cpu cores it is required to prevent the low-level libraries attempting to distribute their workload over multiple threads/cores.
-
 This issue can be solved by constraining the C libraries to single threads, using the following environment variables:
-
-The environment variables in question are, `OMP_NUM_THREADS`, `MKL_NUM_THREADS` and `OPENBLAS_NUM_THREADS`. All of these should be set to `1`. For example, if using a Jupyterlab environment, having the first element of the notebook as the following will achieve this:
 
 .. code:: python
 

--- a/docs/text/tsfresh_on_a_cluster.rst
+++ b/docs/text/tsfresh_on_a_cluster.rst
@@ -211,7 +211,7 @@ The :mod:`tsfresh.utilities.distribution` module contains more information about
 Notes for efficient parallelization
 '''''''''''''''''''''''''''''''''''
 
-By default tsfresh uses parallelization to distribute the single threaded python code out to make use of the multiple threads/cores available on the host machine.
+By default tsfresh uses parallelization to distribute the single-threaded python code to the multiple cores available on the host machine.
 
 However, this can create an issue known as over-provisioning, due to the fact that many of the underlying python libraries this project is built upon drop back into C code implementations for their low-level processing, and `also` try and spread their workload between as many threads/cores available.
 

--- a/docs/text/tsfresh_on_a_cluster.rst
+++ b/docs/text/tsfresh_on_a_cluster.rst
@@ -219,7 +219,7 @@ Over-provisioning is inefficient because of the overheads of repeated context sw
 
 It is far better to give control over this load distribution to the larger tasks, hence using parallelization in tsfresh, but to make best use of this and stop the over-provisioning of cpu cores it is required to prevent the low-level libraries attempting to distribute their workload over multiple threads/cores.
 
-This can be achieved by setting some environment variables early on in the kernel before these underlying python modules get loaded in.
+This issue can be solved by constraining the C libraries to single threads, using the following environment variables:
 
 The environment variables in question are, `OMP_NUM_THREADS`, `MKL_NUM_THREADS` and `OPENBLAS_NUM_THREADS`. All of these should be set to `1`. For example, if using a Jupyterlab environment, having the first element of the notebook as the following will achieve this:
 

--- a/docs/text/tsfresh_on_a_cluster.rst
+++ b/docs/text/tsfresh_on_a_cluster.rst
@@ -232,6 +232,6 @@ The environment variables in question are, `OMP_NUM_THREADS`, `MKL_NUM_THREADS` 
 
 To run the notebook successfully it is then required to use the 'Restart the kernel' option.
 
-The more cores your host computer has, the more improvement in processing speed will be gained by implementing these environment changes. Speed increases of between 6x and 26x have been observed depending on the class of the host machine.
+The more cores your host computer has, the more improvement in processing speed will be gained by implementing these environment changes. Speed increases of between 6x and 26x have been observed depending on the type of the host machine.
 
 

--- a/docs/text/tsfresh_on_a_cluster.rst
+++ b/docs/text/tsfresh_on_a_cluster.rst
@@ -215,7 +215,7 @@ By default tsfresh uses parallelization to distribute the single-threaded python
 
 However, this can create an issue known as over-provisioning. Many of the underlying python libraries (e.g. numpy) used in the feature calculators have C code implementations for their low-level processing. Those `also` try to spread their workload between as many cores available - which is in conflict with the parallelization done by tsfresh.
 
-Over-provisioning is inefficient because of the overheads of repeated context switching. 
+Over-provisioning is inefficient because of the overheads of repeated context switching.
 
 This issue can be solved by constraining the C libraries to single threads, using the following environment variables:
 
@@ -229,5 +229,3 @@ This issue can be solved by constraining the C libraries to single threads, usin
 Put these lines at the beginning of your notebook/python script - before you call any tsfresh code or import any other module.
 
 The more cores your host computer has, the more improvement in processing speed will be gained by implementing these environment changes. Speed increases of between 6x and 26x have been observed depending on the type of the host machine.
-
-

--- a/docs/text/tsfresh_on_a_cluster.rst
+++ b/docs/text/tsfresh_on_a_cluster.rst
@@ -226,9 +226,9 @@ The environment variables in question are, `OMP_NUM_THREADS`, `MKL_NUM_THREADS` 
 .. code:: python
 
     import os
-    os.environ['OMP_NUM_THREADS']="1"
-    os.environ['MKL_NUM_THREADS']="1"
-    os.environ['OPENBLAS_NUM_THREADS']="1"
+    os.environ['OMP_NUM_THREADS'] = "1"
+    os.environ['MKL_NUM_THREADS'] = "1"
+    os.environ['OPENBLAS_NUM_THREADS'] = "1"
 
 To run the notebook successfully it is then required to use the 'Restart the kernel' option.
 


### PR DESCRIPTION
Setting a few environment variables can greatly improve parallelization by removing over-provisioning. I have updated the document section discussing parallelization to show how this can be achieved.