### PR TITLE
Update tsfresh.feature_extraction.feature_calculators.skewness to make it consistent with the design principle of not ignoring nan

### DIFF
--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -757,8 +757,7 @@ def skewness(x):
     """
     if not isinstance(x, pd.Series):
         x = pd.Series(x)
-    return pd.Series.skew(x)
-
+    return pd.Series.skew(x, skipna = False)
 
 @set_property("fctype", "simple")
 @set_property("input", "pd.Series")


### PR DESCRIPTION
The current implementation of `tsfresh.feature_extraction.feature_calculators.skewness` utilizes a function from pandas that ignores `nan` by default, which is not consistent with the performance of other functions and the design principle. 

This update provides a fix by adding a `skipna=False` argument. But since it's discovered simply by chance, I do suggest a review of other parts of the code. 

[More](https://github.com/blue-yonder/tsfresh/issues/90)