### PR TITLE
Make Dask and Distributed optional dependencies

### DIFF
--- a/docs/text/quick_start.rst
+++ b/docs/text/quick_start.rst
@@ -13,6 +13,15 @@ As the compiled tsfresh package is hosted on the Python Package Index (PyPI) you
 
    pip install tsfresh
 
+If you need to work with large time series data that may not fit in memory, install tsfresh with
+`Dask <https://www.dask.org>`_:
+
+.. code:: shell
+
+   pip install tsfresh[dask]
+
+See also :ref:`large-data-label`.
+
 
 Dive in
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ docs =
 
 # Add here test requirements (semicolon/line-separated)
 testing =
-    tsfresh[dask]
+    %(dask)s
     pytest>=4.4.0
     pytest-cov>=2.6.1
     pytest-xdist>=1.26.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,6 @@ install_requires =
     patsy>=0.4.1
     scikit-learn>=0.22.0
     tqdm>=4.10.0
-    dask[dataframe]>=2.9.0
-    distributed>=2.11.0
     stumpy>=1.7.2
     cloudpickle
 
@@ -56,6 +54,9 @@ exclude =
     tests*
 
 [options.extras_require]
+dask =
+    dask[dataframe]>=2.9.0
+    distributed>=2.11.0
 matrixprofile =
     matrixprofile>=1.1.10,<2.0.0
 
@@ -67,6 +68,7 @@ docs =
 
 # Add here test requirements (semicolon/line-separated)
 testing =
+    tsfresh[dask]
     pytest>=4.4.0
     pytest-cov>=2.6.1
     pytest-xdist>=1.26.1


### PR DESCRIPTION
Addresses https://github.com/blue-yonder/tsfresh/discussions/1060.

Dask was de facto optional already (see the guarded import in `tsfresh/feature_extraction/data.py`), but before this PR it was installed by default.

Distributed is imported only to support Dask, when the classes `ClusterDaskDistribution` or `LocalDaskDistribution` are used, so it is not needed if Dask is not imported.

To install tsfresh with those dependencies, one can do:

    pip install -e ".[dask]"

~This is needed, for example, to run the test suite.~ The documentation has been updated accordingly.