### PR TITLE
extract_revant_features now passes chunksize to extract_features

### DIFF
--- a/tsfresh/convenience/relevant_extraction.py
+++ b/tsfresh/convenience/relevant_extraction.py
@@ -189,6 +189,7 @@ def extract_relevant_features(
         profiling_filename=profiling_filename,
         profiling_sorting=profiling_sorting,
         n_jobs=n_jobs,
+        chunksize=chunksize,
         column_id=column_id,
         column_sort=column_sort,
         column_kind=column_kind,


### PR DESCRIPTION
`extract_relevant_features` did previously not pass `chunksize` to `extract_features`, but only to `select_features`