### PR TITLE
Dockerise testing for dev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/psf/black
     rev: 22.12.0

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,0 +1,62 @@
+# Bakes the python versions which tsfresh targets into a testing env
+FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-c"]
+
+# These are required to build python from source
+RUN apt-get update && apt-get install -y \
+    python3-pip \
+    curl \
+    clang \
+    git \
+    build-essential \
+    libssl-dev \
+    libreadline-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libsqlite3-dev \
+    llvm \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libffi-dev \
+    liblzma-dev \
+    libgmp-dev \
+    libmpfr-dev \
+    && apt-get clean
+
+
+RUN curl https://pyenv.run | bash
+
+# For interactive use (if any), this is an edge case.
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PATH"
+ENV PATH="$PYENV_ROOT/shims:$PATH"
+
+ARG PYTHON_VERSIONS
+RUN for version in $PYTHON_VERSIONS; do \
+    echo Installing $version; \
+    # Band aid for https://github.com/pyenv/pyenv/issues/1738
+    # since this also appears to apply to 3.7.X
+    if [[ $version =~ ^3\.7\..*$ ]]; then \
+      echo Using clang to compile $version; \
+      CC=clang pyenv install $version || exit 1; \
+    else \
+      pyenv install $version || exit 1; \
+    fi; \
+    done
+
+RUN pyenv global $PYTHON_VERSIONS
+
+RUN pip install tox
+
+WORKDIR /tsfresh
+
+# Requires adding safe.directory so that tsfresh can build when the
+# repo is mounted.
+# Note cannot do this at build time as no git directory exists
+CMD ["/bin/bash", "-c", "git config --global --add safe.directory /tsfresh && tox -r -p auto"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+WORKDIR := /tsfresh
+TEST_IMAGE := tsfresh-test-image
+TEST_DOCKERFILE := Dockerfile.testing
+TEST_CONTAINER := tsfresh-test-container
+# >= 3.9.2 ---> https://github.com/dask/distributed/issues/7956
+PYTHON_VERSIONS := "3.7.12 3.8.12 3.9.12 3.10.12 3.11.0"
+BLACK_VERSION := 22.12.0
+# Isort 5.12.0 not supported with python 3.7.12
+ISORT_VERSION := 5.12.0
+
+build-testenv:
+	docker build \
+			-f $(TEST_DOCKERFILE) \
+			-t $(TEST_IMAGE) \
+			--build-arg PYTHON_VERSIONS=$(PYTHON_VERSIONS) \
+			.
+
+# Tests `PYTHON_VERSIONS`, provided they are also
+# specified in setup.cfg `envlist`
+test-all-testenv: clean build-testenv
+	docker run --rm \
+			--name $(TEST_CONTAINER) \
+			-v .:$(WORKDIR) \
+			-v build_artifacts:$(WORKDIR)/build \
+			-v tox_artifacts:$(WORKDIR)/.tox \
+			-v egg_artifacts:$(WORKDIR)/tsfresh.egg-info \
+			$(TEST_IMAGE)
+
+# Tests the python binaries installed
+# on local machine, provided they are also
+# specified in setup.cfg `envlist`
+test-all-local: clean
+	tox -r -p auto
+
+# Tests for python version on local machine in
+# current context (e.g. global or local version of
+# python set by pyenv, or the python version in
+# the active virtualenv).
+test-local: clean
+	pip install .[testing]
+	pytest
+
+clean:
+	rm -rf .tox build/ dist/ *.egg-info
+
+install-formatters:
+	pip install black==$(BLACK_VERSION) isort==$(ISORT_VERSION)
+
+format: install-formatters
+	black --extend-exclude \.docs .
+	isort --profile black --skip-glob="docs" .
+
+.PHONY: clean test-all-local test-local test-all-testenv format install-formatters

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,20 @@ WORKDIR := /tsfresh
 TEST_IMAGE := tsfresh-test-image
 TEST_DOCKERFILE := Dockerfile.testing
 TEST_CONTAINER := tsfresh-test-container
-# >= 3.9.2 ---> https://github.com/dask/distributed/issues/7956
-PYTHON_VERSIONS := "3.7.12 3.8.12 3.9.12 3.10.12 3.11.0"
-BLACK_VERSION := 22.12.0
-# Isort 5.12.0 not supported with python 3.7.12
-ISORT_VERSION := 5.12.0
+PYTHON_VERSIONS := "3.7 3.8 3.9 3.10 3.11"
 
-build-testenv:
+# Tests `PYTHON_VERSIONS`, provided they are also
+# specified in setup.cfg `envlist`
+test-all-testenv: build-docker-testenv run-docker-tests clean
+
+build-docker-testenv:
 	docker build \
 			-f $(TEST_DOCKERFILE) \
 			-t $(TEST_IMAGE) \
 			--build-arg PYTHON_VERSIONS=$(PYTHON_VERSIONS) \
 			.
 
-# Tests `PYTHON_VERSIONS`, provided they are also
-# specified in setup.cfg `envlist`
-test-all-testenv: clean build-testenv
+run-docker-tests:
 	docker run --rm \
 			--name $(TEST_CONTAINER) \
 			-v .:$(WORKDIR) \
@@ -26,28 +24,8 @@ test-all-testenv: clean build-testenv
 			-v egg_artifacts:$(WORKDIR)/tsfresh.egg-info \
 			$(TEST_IMAGE)
 
-# Tests the python binaries installed
-# on local machine, provided they are also
-# specified in setup.cfg `envlist`
-test-all-local: clean
-	tox -r -p auto
-
-# Tests for python version on local machine in
-# current context (e.g. global or local version of
-# python set by pyenv, or the python version in
-# the active virtualenv).
-test-local: clean
-	pip install .[testing]
-	pytest
-
 clean:
 	rm -rf .tox build/ dist/ *.egg-info
 
-install-formatters:
-	pip install black==$(BLACK_VERSION) isort==$(ISORT_VERSION)
 
-format: install-formatters
-	black --extend-exclude \.docs .
-	isort --profile black --skip-glob="docs" .
-
-.PHONY: clean test-all-local test-local test-all-testenv format install-formatters
+.PHONY: build-docker-testenv clean run-docker-tests test-all-testenv

--- a/docs/text/how_to_contribute.rst
+++ b/docs/text/how_to_contribute.rst
@@ -64,7 +64,7 @@ you have to:
 
 .. code::
 
-    make test-local
+    pytest
 
 
 To test changes across multiple versions of Python, run:
@@ -72,10 +72,10 @@ To test changes across multiple versions of Python, run:
 
 .. code::
 
-    make test-all-local
+    tox -r -p auto
 
 
-This will execute tests for the Python versions specified in `setup.cfg <https://github.com/blue-yonder/tsfresh/blob/1297c8ca5bd6f8f23b4de50e3f052fb4ec1307f8/setup.cfg>`_ using the `envlist` variable. For example, if `envlist` is set to `py37, py38`, the test suite will run for Python 3.7 and 3.8 on the local development platform, assuming the binaries for those versions are available locally. The exact Python microversions (e.g. `3.7.1` vs `3.7.2`) depend on what is installed on the local development machine.
+This will execute tests for the Python versions specified in `setup.cfg <https://github.com/blue-yonder/tsfresh/blob/main/setup.cfg>`_ using the `envlist` variable. For example, if `envlist` is set to `py37, py38`, the test suite will run for Python 3.7 and 3.8 on the local development platform, assuming the binaries for those versions are available locally. The exact Python microversions (e.g. `3.7.1` vs `3.7.2`) depend on what is installed on the local development machine.
 
 A recommended way to manage multiple Python versions when testing locally is with `pyenv`, which enables organized installation and switching between versions.
 

--- a/docs/text/how_to_contribute.rst
+++ b/docs/text/how_to_contribute.rst
@@ -64,7 +64,7 @@ you have to:
 
 .. code::
 
-    pytest
+    make test-local
 
 
 To test changes across multiple versions of Python, run:
@@ -72,12 +72,23 @@ To test changes across multiple versions of Python, run:
 
 .. code::
 
-    tox -r
+    make test-all-local
 
 
-`tox -r` will execute tests for the Python versions specified in `setup.cfg <https://github.com/blue-yonder/tsfresh/blob/1297c8ca5bd6f8f23b4de50e3f052fb4ec1307f8/setup.cfg>`_ using the `envlist` variable. For example, if `envlist` is set to `py37, py38`, the test suite will run for Python 3.7 and 3.8 on the local development platform, assuming the binaries for those versions are available locally. The exact Python microversions (e.g. `3.7.1` vs `3.7.2`) depend on what is installed on the local development machine.
+This will execute tests for the Python versions specified in `setup.cfg <https://github.com/blue-yonder/tsfresh/blob/1297c8ca5bd6f8f23b4de50e3f052fb4ec1307f8/setup.cfg>`_ using the `envlist` variable. For example, if `envlist` is set to `py37, py38`, the test suite will run for Python 3.7 and 3.8 on the local development platform, assuming the binaries for those versions are available locally. The exact Python microversions (e.g. `3.7.1` vs `3.7.2`) depend on what is installed on the local development machine.
 
 A recommended way to manage multiple Python versions when testing locally is with `pyenv`, which enables organized installation and switching between versions.
+
+In addition to running tests locally, you can also run them in a Dockerized testing environment:
+
+
+.. code::
+
+   make test-all-testenv
+
+
+This command will initially take some time. However subsequent invokations will be faster, and testing this way ensures a clean, consistent test environment, regardless of your local setup.
+
 
 Documentation
 '''''''''''''


### PR DESCRIPTION
Related: https://github.com/blue-yonder/tsfresh/pull/994. 

Easiest to go commit by commit. Uses 3 "flows"

(1) **Test locally on specific python version** Is useful for quick iteration.
(2) **Test locally on the discoverable python versions** Is a useful sanity check for ensuring new development works on multiple versions of python. 
(3) **Test in dedicated testing environment with guaranteed availability of python versions** Is a good final sanity check. Takes longer, but creates a reproducible environment to test off and is a good 'source of truth'.


### 1 Test locally on specific python version

Testing time for one version is ~1 min. Note this includes the speedup from cached packages

### 2 Test locally on the discoverable python versions

![image](https://github.com/user-attachments/assets/773b6ec3-32ea-4bee-946e-e9f167903b6e)

Testing time across versions 3.7-3.11 is ~4 mins, but note that this speedup includes the speedup from cached packages.

Also note that python 3.7 fails on my machine due to some idiosyncratic issue related to my setup `py37/lib/python3.7/site-packages/pip/_vendor/typing_extensions.py` ... getting same error as [here](https://github.com/microsoft/vscode/issues/200543) but not using vscode. Not an issue for me personally but shows an example of why testing within an isolated testing environment could be a good way to ensure reproducible version targeting. 

### 3 Test in dedicated testing environment with guaranteed availability of python versions 

![image](https://github.com/user-attachments/assets/b65709cc-8f3c-45a0-9ea3-53092c086fb4)

Build time for testenv ~5 mins but this is a once-off build for the testenv.

Testing time across versions 3.7-->3.11 is ~6 mins.