### PR TITLE
Drop old versions of python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9, 3.10, 3.11, 3.12]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12]
     steps:
       - uses: actions/checkout@v3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,8 @@ install_requires =
     requests>=2.9.1
     numpy >=1.15.1
     pandas>=0.25.0
-    scipy>=1.14.0;python_version>='3.10'
-    scipy>=1.2.0;python_version<'3.10'
+    scipy>=1.14.0,<1.15;python_version>='3.10'
+    scipy>=1.2.0,<1.15;python_version<'3.10'
     statsmodels>=0.13
     patsy>=0.4.1
     scikit-learn>=0.22.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     cloudpickle
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >= 3.7
+python_requires = >= 3.9
 
 [options.packages.find]
 where = .


### PR DESCRIPTION
Drop support for deprecated python version 3.7 an 3.8.
Also, add tests for 3.10-3.12.

Until #1097 is in, constrain the version of scipy to make the CI/CD still work.