### PR TITLE
Bump version support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ WORKDIR := /tsfresh
 TEST_IMAGE := tsfresh-test-image
 TEST_DOCKERFILE := Dockerfile.testing
 TEST_CONTAINER := tsfresh-test-container
-PYTHON_VERSIONS := "3.7 3.8 3.9 3.10 3.11"
+PYTHON_VERSIONS := "3.9 3.10 3.11"
 
 # Tests `PYTHON_VERSIONS`, provided they are also
 # specified in setup.cfg `envlist`

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ WORKDIR := /tsfresh
 TEST_IMAGE := tsfresh-test-image
 TEST_DOCKERFILE := Dockerfile.testing
 TEST_CONTAINER := tsfresh-test-container
-PYTHON_VERSIONS := "3.9 3.10 3.11"
+PYTHON_VERSIONS := "3.9 3.10 3.11 3.12"
 
 # Tests `PYTHON_VERSIONS`, provided they are also
 # specified in setup.cfg `envlist`

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,9 @@ classifier =
     Development Status :: 4 - Beta
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3 :: Only
     Operating System :: Unix
     Operating System :: Microsoft :: Windows
@@ -145,7 +144,7 @@ package = tsfresh
 # Tox global conifguration options
 minversion = 4.0.0
 # Which python versions to test for
-envlist = py37, py38, py39, py310, py311
+envlist = py39, py310, py311
 # Don't throw an error if a specific version of python is not installed
 skip_missing_interpreters = True
 # Ensure that tox uses a virtual environment to build a source distribution

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifier =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
     Operating System :: Unix
     Operating System :: Microsoft :: Windows
@@ -144,7 +145,7 @@ package = tsfresh
 # Tox global conifguration options
 minversion = 4.0.0
 # Which python versions to test for
-envlist = py39, py310, py311
+envlist = py39, py310, py311, py312
 # Don't throw an error if a specific version of python is not installed
 skip_missing_interpreters = True
 # Ensure that tox uses a virtual environment to build a source distribution


### PR DESCRIPTION
PR updates setup.cfg to reflect the fact that tsfresh no longer targets < 3.9. See https://github.com/blue-yonder/tsfresh/commit/d66fc0fdfe3db9c3ac50594878367da03e113c83 for context.

PR also explicitly adds targeting of python 3.12