### PR TITLE
Add bisect debug helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ clean:
 	rm -rf .tox build/ dist/ *.egg-info
 
 bisect:
+	@if [ -z "$(GOOD_COMMIT)" ]; then \
+		echo "Error: GOOD_COMMIT is required. Usage: make bisect GOOD_COMMIT=<commit_hash>."; \
+		echo "Assumes that the current checked-out commit is a known bad commit, and bisects from there."; \
+		exit 1; \
+	fi
 	git bisect start
 	git bisect bad
 	git bisect good $(GOOD_COMMIT)

--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,11 @@ run-docker-tests:
 clean:
 	rm -rf .tox build/ dist/ *.egg-info
 
+bisect:
+	git bisect start
+	git bisect bad
+	git bisect good $(GOOD_COMMIT)
+	git bisect run pytest
+	git bisect reset
 
-.PHONY: build-docker-testenv clean run-docker-tests test-all-testenv
+.PHONY: build-docker-testenv clean run-docker-tests test-all-testenv bisect


### PR DESCRIPTION
Add Git Bisect Helper to Automate Regression Debugging.

During the process of feature development not part of this PR, I used git bisect` to help identify the commit that introduced a bug (the bug in question was caused by a variable name clashing with a function name).

Adding this git bisect helper to the main line as it has a great impact on automated bug finding (when the commits are atomic).
