### PR TITLE
Fix python version used in benchmark

### DIFF
--- a/.github/workflows/benchmark_default_branch.yml
+++ b/.github/workflows/benchmark_default_branch.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
One thing left from the recent change to drop old python versions.