### PR TITLE
Speedup approx entropy

### DIFF
--- a/tsfresh/feature_extraction/feature_calculators.py
+++ b/tsfresh/feature_extraction/feature_calculators.py
@@ -28,6 +28,7 @@ import pandas as pd
 import stumpy
 from numpy.linalg import LinAlgError
 from scipy.signal import cwt, find_peaks_cwt, ricker, welch
+from scipy.spatial.distance import cdist
 from scipy.stats import linregress
 from statsmodels.tools.sm_exceptions import MissingDataError
 from statsmodels.tsa.ar_model import AutoReg
@@ -1782,7 +1783,7 @@ def approximate_entropy(x, m, r):
     def _phi(m):
         x_re = np.array([x[i : i + m] for i in range(N - m + 1)])
         C = np.sum(
-            np.max(np.abs(x_re[:, np.newaxis] - x_re[np.newaxis, :]), axis=2) <= r,
+            cdist(x_re, x_re, metric="chebyshev") <= r,
             axis=0,
         ) / (N - m + 1)
         return np.sum(np.log(C)) / (N - m + 1.0)


### PR DESCRIPTION
`np.max(np.abs(x_re[:, np.newaxis] - x_re[np.newaxis, :]), axis=2) <= r` was identified as a hotspot on the [scalene]() profiler.* 

This PR speeds this up.

Here is a snippet of before optimisations made:

![image](https://github.com/user-attachments/assets/03ad705f-d295-4c42-b6af-0748fe973472)

Here is after changes made:

![image](https://github.com/user-attachments/assets/94f3d581-0047-40cc-846a-01bedf6448ca)

It goes up, so this may be a red herring hotspot. Profiling the individual line change showed a massive speedup, but overall it harms performance... leaving in draft for now

### Reproduce profiling results with:

```python
from tsfresh.examples import robot_execution_failures
from tsfresh import extract_features
from tsfresh.utilities.dataframe_functions import impute
import pandas as pd
robot_execution_failures.download_robot_execution_failures()
df, y = robot_execution_failures.load_robot_execution_failures(
)
df_large = pd.concat([df]*100, ignore_index=True)
X = extract_features(
    df_large,
    column_id='id',
    column_sort='time',
    impute_function=impute,
    disable_progressbar=True,
)
```

```bash
scalene --cpu --profile --multiprocessing profile_tsfresh.py
```

Scalene profiler is so much better than any other python profiling tooIs I found at identifying hotspots on python code specifically code that leverages multiprocessing, where cProfile can be confusing. 



 