### PR TITLE
ENH: Add min_timeshift support to make_forecasting_frame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ docs/text/_generated/
 
 # Virtual environment
 venv*
+.venv/
 activate
 
 # IPython notebooks

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -1468,6 +1468,30 @@ class MakeForecastingFrameTestCase(TestCase):
             default_fc_parameters=MinimalFCParameters(),
         )
 
+    def test_make_forecasting_frame_min_timeshift(self):
+        x = pd.Series([1, 2, 3, 4, 5])
+        # Default behavior
+        df_default, y_default = dataframe_functions.make_forecasting_frame(
+            x=x,
+            kind="test",
+            max_timeshift=3,
+            rolling_direction=1,
+        )
+        # With min_timeshift
+        df_filtered, y_filtered = dataframe_functions.make_forecasting_frame(
+            x=x,
+            kind="test",
+            max_timeshift=3,
+            rolling_direction=1,
+            min_timeshift=2,
+        )
+        # Check fewer rows (core behavior)
+        assert len(df_filtered) < len(df_default)
+        # Check target is aligned
+        assert len(y_filtered) == len(df_filtered.groupby("id").size())
+        # assert in filtered_df each "time" >= 2
+        assert all(df_filtered["time"] >= 2)
+
 
 class GetIDsTestCase(TestCase):
     def test_get_id__correct_DataFrame(self):

--- a/tests/units/utilities/test_dataframe_functions.py
+++ b/tests/units/utilities/test_dataframe_functions.py
@@ -1485,12 +1485,25 @@ class MakeForecastingFrameTestCase(TestCase):
             rolling_direction=1,
             min_timeshift=2,
         )
-        # Check fewer rows (core behavior)
-        assert len(df_filtered) < len(df_default)
-        # Check target is aligned
-        assert len(y_filtered) == len(df_filtered.groupby("id").size())
-        # assert in filtered_df each "time" >= 2
-        assert all(df_filtered["time"] >= 2)
+        # check actual filtered df length
+        assert len(df_filtered) == len(df_default) - 1
+        # Check target alignment
+        assert len(y_filtered) == df_filtered["id"].nunique()
+        # check df index matching
+        df_common_ids = set(df_filtered["id"])
+        df_default_intersection = (
+            df_default[df_default["id"].isin(df_common_ids)]
+            .sort_values(["id", "time"])
+            .reset_index(drop=True)
+        )
+        df_filtered = df_filtered.sort_values(["id", "time"]).reset_index(drop=True)
+        pd.testing.assert_frame_equal(df_default_intersection, df_filtered)
+        # check target index matching
+        y_common_index = y_filtered.index
+        y_default_intersection = y_default.loc[y_common_index]
+        pd.testing.assert_series_equal(
+            y_default_intersection.sort_index(), y_filtered.sort_index()
+        )
 
 
 class GetIDsTestCase(TestCase):

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -579,7 +579,7 @@ def roll_time_series(
     return df_shift.sort_values(by=["id", column_sort or "sort"])
 
 
-def make_forecasting_frame(x, kind, max_timeshift, rolling_direction):
+def make_forecasting_frame(x, kind, max_timeshift, rolling_direction, min_timeshift=0):
     """
     Takes a singular time series x and constructs a DataFrame df and target vector y that can be used for a time series
     forecasting task.
@@ -603,6 +603,8 @@ def make_forecasting_frame(x, kind, max_timeshift, rolling_direction):
     :type rolling_direction: int
     :param max_timeshift: If not None, shift only up to max_timeshift. If None, shift as often as possible.
     :type max_timeshift: int
+    :param min_timeshift: Minimum shift size to begin creating windows. Smaller windows are discarded. Default is 0.
+    :type min_timeshift: int
 
     :return: time series container df, target vector y
     :rtype: (pd.DataFrame, pd.Series)
@@ -623,6 +625,7 @@ def make_forecasting_frame(x, kind, max_timeshift, rolling_direction):
         column_kind="kind",
         rolling_direction=rolling_direction,
         max_timeshift=max_timeshift,
+        min_timeshift=min_timeshift,
     )
 
     # drop the rows which should actually be predicted
@@ -645,6 +648,11 @@ def make_forecasting_frame(x, kind, max_timeshift, rolling_direction):
     # make sure that the format is the same as the
     # df_shift index
     y.index = map(lambda x: ("id", x), y.index)
+
+    # align y with df_shift ids
+    # align y with df_shift ids
+    valid_ids = set(df_shift["id"].unique())
+    y = y[y.index.isin(valid_ids)]
 
     return df_shift, y
 

--- a/tsfresh/utilities/dataframe_functions.py
+++ b/tsfresh/utilities/dataframe_functions.py
@@ -650,7 +650,6 @@ def make_forecasting_frame(x, kind, max_timeshift, rolling_direction, min_timesh
     y.index = map(lambda x: ("id", x), y.index)
 
     # align y with df_shift ids
-    # align y with df_shift ids
     valid_ids = set(df_shift["id"].unique())
     y = y[y.index.isin(valid_ids)]
 


### PR DESCRIPTION
## Summary
This PR introduces a `min_timeshift` parameter to `make_forecasting_frame` to allow filtering out early time steps in forecasting frame generation.

## Why
As highlighted in issue #992, 'make_forecasting_frame' was missing a 'min_timeshift' parameters. I saw this issue was still open and implemented the suggested enhancement.

## Files changed
- `tsfresh/utilities/dataframe_functions.py`: added `min_timeshift` filtering logic
- `tests/units/utilities/test_dataframe_functions.py`: added unit test for `min_timeshift`

## Function enhancement
- Added `min_timeshift` parameter to `make_forecasting_frame`. 
- 'min_timeshift' defaults to 0 for backward compatibility
- Filtered out generated rows where time index < 'min_timeshift'
- Updated unit test to validate filtering behavior

## Testing
- Verified correct filtering behavior using synthetic time series and boundary checks
- All unit tests pass locally (`pytest`)

### Notes
- `.gitignore` updated to exclude `.venv/` during local development

Fixes #992 